### PR TITLE
Bucket exists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-* @schucly @arttor @fa-at-pulsit
+* @schucly @arttor @fa-at-pulsit @aiivashchenko

--- a/test/migration/init_test.go
+++ b/test/migration/init_test.go
@@ -203,7 +203,7 @@ func TestMain(m *testing.M) {
 	go func() {
 		app := dom.AppInfo{
 			Version: "test",
-			App:     "proxy",
+			App:     "worker",
 			AppID:   xid.New().String(),
 		}
 		workerCtx, cancelFn := context.WithCancel(ctx)


### PR DESCRIPTION
Fix for RGW edge-case:
- if destination bucket was created with SWIFT API with "_" in its name and `rgw_relaxed_s3_bucket_names` is disabled.