### PR TITLE
chorus mgmt api: don't send nil as toBucket in replication responses

### DIFF
--- a/pkg/api/mappers.go
+++ b/pkg/api/mappers.go
@@ -1,5 +1,6 @@
 /*
  * Copyright © 2024 Clyso GmbH
+ * Copyright © 2025 STRATO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +35,19 @@ func tsToPb(ts *time.Time) *timestamppb.Timestamp {
 }
 
 func replicationToPb(in policy.ReplicationPolicyStatusExtended) *pb.Replication {
+	var toBucket *string
+	if in.ToBucket == nil {
+		toBucket = &in.Bucket
+	} else {
+		toBucket = in.ToBucket
+	}
+
 	return &pb.Replication{
 		User:            in.User,
 		Bucket:          in.Bucket,
 		From:            in.From,
 		To:              in.To,
-		ToBucket:        in.ToBucket,
+		ToBucket:        toBucket,
 		CreatedAt:       timestamppb.New(in.CreatedAt),
 		IsPaused:        in.IsPaused,
 		IsInitDone:      in.ReplicationPolicyStatus.InitDone(),


### PR DESCRIPTION
If a replication has no custom destination name configured, the name of the source bucket is used for the destination aswell. In that case, the mgmt API used to send a response with the `ToBucket` field set to `nil`.

Clients had to:
1.  Handle both cases, a response `ToBucket` set to `nil` and a response where `ToBucket` is a string value
2. Be aware that a `nil` value in the `ToBucket` field implicitly uses the name of the source bucket for the replication destination.

With this change, the `ToBucket` field is always set to a string value.

The motivation is to remove boilerplate code from mgmt-API clients to make them simpler and less error-prone

Even though the old behavior is not strictly wrong and the change is not strictly necessary, I think that it is beneficial for client implementations.

Since all useful clients should be able to handle a string value for `ToBucket`, the change should not brake any existing code. 

The drawback of this approach is that clients can not distinguish between a replication without custom destination (which uses the implied default) , and a replication which has the destination bucket explicitly set to the source buckets name anymore.