### PR TITLE
standalone: don't print secrets by default

### DIFF
--- a/service/standalone/start.go
+++ b/service/standalone/start.go
@@ -183,10 +183,12 @@ func Start(ctx context.Context, app dom.AppInfo, conf *Config) error {
 		return err
 	}
 
+	_, useFakeStorageCreds := fake[conf.Proxy.Auth.UseStorage]
+
 	fmt.Printf(connectInfo,
 		uiURL,
 		proxyURL,
-		printCreds(conf),
+		printCreds(conf, useFakeStorageCreds),
 		localhost(conf.Api.GrpcPort),
 		httpLocalhost(conf.Api.HttpPort),
 		redisSvc.Addr(),
@@ -204,7 +206,7 @@ func localhost(port int) string {
 	return fmt.Sprintf("127.0.0.1:%d", port)
 }
 
-func printCreds(conf *Config) string {
+func printCreds(conf *Config, printSecrets bool) string {
 	if !conf.Proxy.Enabled {
 		return ""
 	}
@@ -219,7 +221,11 @@ func printCreds(conf *Config) string {
 	}
 	res := make([]string, 0, len(creds))
 	for s, v4 := range creds {
-		res = append(res, fmt.Sprintf(" - %s: [%s|%s]", s, v4.AccessKeyID, v4.SecretAccessKey))
+		secret := "<hidden>"
+		if printSecrets {
+			secret = v4.SecretAccessKey
+		}
+		res = append(res, fmt.Sprintf(" - %s: [%s|%s]", s, v4.AccessKeyID, secret))
 	}
 	return strings.Join(res, "\n")
 }


### PR DESCRIPTION
By default, the standalone proxy prints all configured credentials on startup, including the secret access keys.

While this behavior is useful for test scenarios (e.g. when in-memory fake storages are used), this can be considered a security issue, depending on the environment where the service is running.

If the standalone proxy instance finds and uses a valid configuration (either on purpose or by accident), all configured secrets are exposed to STDOUT and might end up in log files (or worse).

With this commit, the standalone proxy avoids printing the secret keys unless printing of secrets is explicitly requested in the config.

This is a non-breaking change. Nothing but the text printed on standalone-startup is modified, and the old behavior can be provoked using the introduced switch,