### PR TITLE
disable container logs option for test env

### DIFF
--- a/test/env/containers.go
+++ b/test/env/containers.go
@@ -17,6 +17,7 @@ package env
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"runtime"
@@ -38,6 +39,12 @@ import (
 	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+//go:embed proxy-server.conf
+var proxyServerConf []byte
+
+//go:embed ceph-entrypoint.sh
+var cephEntrypointSh []byte
 
 const (
 	CRedisImage    = "redis:8.0.1-alpine"
@@ -94,15 +101,24 @@ const (
 
 type ContainerLogConsumer struct {
 	componentName string
+	disabledLogs  map[ContainerLogType]struct{}
 }
 
-func NewContainerLogConsumer(componenetName string) *ContainerLogConsumer {
+func NewContainerLogConsumer(componenetName string, disabled []ContainerLogType) *ContainerLogConsumer {
+	d := make(map[ContainerLogType]struct{}, len(disabled))
+	for _, logType := range disabled {
+		d[logType] = struct{}{}
+	}
 	return &ContainerLogConsumer{
 		componentName: componenetName,
+		disabledLogs:  d,
 	}
 }
 
 func (r *ContainerLogConsumer) Accept(l testcontainers.Log) {
+	if _, ok := r.disabledLogs[ContainerLogType(l.LogType)]; ok {
+		return
+	}
 	fmt.Printf("%s %s %s", r.componentName, l.LogType, l.Content)
 }
 
@@ -119,6 +135,7 @@ type ContainerPort struct {
 type ComponentCreationConfig struct {
 	Dependencies    []string
 	InstantiateFunc func(context.Context, *TestEnvironment, string, *ComponentCreationConfig) error
+	DisabledLogs    []ContainerLogType
 }
 
 type RedisAccessConfig struct {
@@ -290,36 +307,56 @@ func (r *TestEnvironment) GetCephAccessConfig(instanceName string) (*CephAccessC
 	return &cephAccessCfg, nil
 }
 
-func AsMinio() ComponentCreationConfig {
-	return ComponentCreationConfig{
+func AsMinio(opts ...Option) ComponentCreationConfig {
+	cfg := ComponentCreationConfig{
 		InstantiateFunc: startMinioInstance,
 	}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return cfg
 }
 
-func AsRedis() ComponentCreationConfig {
-	return ComponentCreationConfig{
+func AsRedis(opts ...Option) ComponentCreationConfig {
+	cfg := ComponentCreationConfig{
 		InstantiateFunc: startRedisInstance,
 	}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return cfg
 }
 
-func AsKeystone() ComponentCreationConfig {
-	return ComponentCreationConfig{
+func AsKeystone(opts ...Option) ComponentCreationConfig {
+	cfg := ComponentCreationConfig{
 		InstantiateFunc: startKeystoneInstance,
 	}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return cfg
 }
 
-func AsSwift(keystoneInstance string) ComponentCreationConfig {
-	return ComponentCreationConfig{
+func AsSwift(keystoneInstance string, opts ...Option) ComponentCreationConfig {
+	cfg := ComponentCreationConfig{
 		Dependencies:    []string{keystoneInstance},
 		InstantiateFunc: startSwiftInstance,
 	}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return cfg
 }
 
-func AsCeph(keystoneInstance string) ComponentCreationConfig {
-	return ComponentCreationConfig{
+func AsCeph(keystoneInstance string, opts ...Option) ComponentCreationConfig {
+	cfg := ComponentCreationConfig{
 		Dependencies:    []string{keystoneInstance},
 		InstantiateFunc: startCephInstance,
 	}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return cfg
 }
 
 func vlan(ctx context.Context) (*testcontainers.DockerNetwork, error) {
@@ -454,7 +491,7 @@ func startSwiftInstance(ctx context.Context, env *TestEnvironment, componentName
 		ResellerRole:     resellerRole.Name,
 	}
 
-	swiftProxyTemplate, err := template.ParseFiles("./proxy-server.conf")
+	swiftProxyTemplate, err := template.New("proxy-server.conf").Parse(string(proxyServerConf))
 	if err != nil {
 		return fmt.Errorf("unable to create swift proxy config template: %w", err)
 	}
@@ -484,7 +521,7 @@ func startSwiftInstance(ctx context.Context, env *TestEnvironment, componentName
 		},
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{
 			Opts:      []testcontainers.LogProductionOption{testcontainers.WithLogProductionTimeout(1 * time.Second)},
-			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName)},
+			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName, componentConfig.DisabledLogs)},
 		},
 	}
 
@@ -567,7 +604,7 @@ func startKeystoneInstance(ctx context.Context, env *TestEnvironment, componentN
 		Networks:     []string{env.network.Name},
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{
 			Opts:      []testcontainers.LogProductionOption{testcontainers.WithLogProductionTimeout(1 * time.Second)},
-			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName)},
+			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName, componentConfig.DisabledLogs)},
 		},
 	}
 
@@ -681,7 +718,7 @@ func startRedisInstance(ctx context.Context, env *TestEnvironment, componentName
 		Networks:     []string{env.network.Name},
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{
 			Opts:      []testcontainers.LogProductionOption{testcontainers.WithLogProductionTimeout(1 * time.Second)},
-			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName)},
+			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName, componentConfig.DisabledLogs)},
 		},
 	}
 
@@ -741,7 +778,7 @@ func startMinioInstance(ctx context.Context, env *TestEnvironment, componentName
 		Networks:     []string{env.network.Name},
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{
 			Opts:      []testcontainers.LogProductionOption{testcontainers.WithLogProductionTimeout(1 * time.Second)},
-			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName)},
+			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName, componentConfig.DisabledLogs)},
 		},
 	}
 
@@ -887,7 +924,7 @@ func startCephInstance(ctx context.Context, env *TestEnvironment, componentName 
 		ResellerRole:     resellerRole.Name,
 	}
 
-	cephRGWConfigTemplate, err := template.ParseFiles("./ceph-entrypoint.sh")
+	cephRGWConfigTemplate, err := template.New("ceph-entrypoint.sh").Parse(string(cephEntrypointSh))
 	if err != nil {
 		return fmt.Errorf("unable to create ceph proxy config template: %w", err)
 	}
@@ -937,7 +974,7 @@ func startCephInstance(ctx context.Context, env *TestEnvironment, componentName 
 		},
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{
 			Opts:      []testcontainers.LogProductionOption{testcontainers.WithLogProductionTimeout(1 * time.Second)},
-			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName)},
+			Consumers: []testcontainers.LogConsumer{NewContainerLogConsumer(componentName, componentConfig.DisabledLogs)},
 		},
 	}
 

--- a/test/env/containers_options.go
+++ b/test/env/containers_options.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Clyso GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import "github.com/testcontainers/testcontainers-go"
+
+type ContainerLogType string
+
+const (
+	// Represents container standard output log.
+	LogStdout ContainerLogType = testcontainers.StdoutLog
+	// Represents container standard error log.
+	LogStderr ContainerLogType = testcontainers.StderrLog
+)
+
+// Option interface to support Functional options for test-containers.
+// Allows to pass different options to a function as variadic parameters.
+// see: https://github.com/uber-go/guide/blob/master/style.md#functional-options
+type Option interface {
+	apply(*ComponentCreationConfig)
+}
+
+type disableContainerLogOption struct {
+	types []ContainerLogType
+}
+
+func (o disableContainerLogOption) apply(cfg *ComponentCreationConfig) {
+	cfg.DisabledLogs = append(cfg.DisabledLogs, o.types...)
+}
+
+// WithDisabledLog returns an Option that disables the specified container logs.
+func WithDisabledLog(types ...ContainerLogType) Option {
+	return disableContainerLogOption{types: types}
+}

--- a/test/env/suite_test.go
+++ b/test/env/suite_test.go
@@ -77,9 +77,9 @@ var _ = BeforeSuite(func() {
 	suiteCtx = context.Background()
 
 	componentConfig := map[string]ComponentCreationConfig{
-		CMinioTestComponentKey:    AsMinio(),
+		CMinioTestComponentKey:    AsMinio(WithDisabledLog(LogStdout, LogStderr)), // Example:Disable all logs for minio component
 		CKeystoneTestComponentKey: AsKeystone(),
-		CRedisTestComponentKey:    AsRedis(),
+		CRedisTestComponentKey:    AsRedis(WithDisabledLog(LogStdout)), // Example:Disable stdout logs for redis component
 		CSwiftTestComponentKey:    AsSwift(CKeystoneTestComponentKey),
 		CCephTestComponentKey:     AsCeph(CKeystoneTestComponentKey),
 	}


### PR DESCRIPTION
## Pull Request

### Description

- fixed relative path bug when test env is used from different pkg
- added option to force disable container logs

### Related Issue
Link to the GitHub issue (if applicable): none

### Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [ ] My commits include a `Signed-off-by` line to certify agreement with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
- [ ] `make test` passing
- [ ] I have updated documentation in [README.md](README.md) if applicable.

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
