### PR TITLE
check redis schema compatibility on start

### DIFF
--- a/pkg/policy/detect_changes.go
+++ b/pkg/policy/detect_changes.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Clyso GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/clyso/chorus/pkg/dom"
+)
+
+const (
+	minSchemaVersion     = 2
+	currentSchemaVersion = 2
+	schemaVersionKey     = "chorus_schema"
+)
+
+func CheckSchemaCompatibility(ctx context.Context, chorusVersion string, client redis.UniversalClient) error {
+	// Check current schema version in Redis
+	version, err := client.Get(ctx, schemaVersionKey).Int()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return fmt.Errorf("failed to get schema version: %w", err)
+	}
+	if version >= minSchemaVersion {
+		return nil
+	}
+
+	// Check for existing keys
+	keys, _, err := client.Scan(ctx, 0, "*", 5).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return fmt.Errorf("failed to scan for existing keys: %w", err)
+	}
+
+	onlySchemaVersionKey := len(keys) == 1 && keys[0] == schemaVersionKey
+
+	if !onlySchemaVersionKey && len(keys) > 0 {
+		return fmt.Errorf("%w: Chorus version %s is incompatible with existing Redis schema from previous Chorus installations. Please remove all data in Redis to continue with the current version, or use Chorus v0.5.15 or older", dom.ErrInternal, chorusVersion)
+	}
+	// No legacy keys found, consider schema compatible
+	// Set the current schema version to not check again next time
+	err = client.Set(ctx, schemaVersionKey, currentSchemaVersion, 0).Err()
+	if err != nil {
+		return fmt.Errorf("failed to set schema version: %w", err)
+	}
+	return nil
+}

--- a/pkg/policy/detect_changes_test.go
+++ b/pkg/policy/detect_changes_test.go
@@ -1,0 +1,54 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/clyso/chorus/pkg/dom"
+	"github.com/clyso/chorus/pkg/testutil"
+)
+
+func TestCheckSchemaCompatibility(t *testing.T) {
+	c := testutil.SetupRedis(t)
+	r := require.New(t)
+	ctx := t.Context()
+
+	t.Run("compatible empty", func(t *testing.T) {
+		c.FlushAll(ctx)
+
+		err := CheckSchemaCompatibility(ctx, "v0.6.0", c)
+		r.NoError(err)
+		// check that schema version is set
+		v, err := c.Get(ctx, schemaVersionKey).Int()
+		r.NoError(err)
+		r.Equal(currentSchemaVersion, v)
+		//repeat should be ok
+		err = CheckSchemaCompatibility(ctx, "v0.6.0", c)
+		r.NoError(err)
+	})
+
+	t.Run("has legacy route key", func(t *testing.T) {
+		c.FlushAll(ctx)
+		err := c.Set(ctx, "p:route:ceph", "value", 0).Err()
+		r.NoError(err)
+
+		err = CheckSchemaCompatibility(ctx, "v0.6.0", c)
+		r.Error(err)
+		r.ErrorIs(err, dom.ErrInternal)
+	})
+
+	t.Run("has legacy repl key", func(t *testing.T) {
+		c.FlushAll(ctx)
+		err := c.ZAdd(ctx, "p:repl:from", redis.Z{
+			Score:  5,
+			Member: "to:buck",
+		}).Err()
+		r.NoError(err)
+
+		err = CheckSchemaCompatibility(ctx, "v0.6.0", c)
+		r.Error(err)
+		r.ErrorIs(err, dom.ErrInternal)
+	})
+}

--- a/service/agent/server.go
+++ b/service/agent/server.go
@@ -85,6 +85,10 @@ func Start(ctx context.Context, app dom.AppInfo, conf *Config) error {
 	inspector := asynq.NewInspector(queueRedis)
 	defer inspector.Close()
 	queueSvc := tasks.NewQueueService(taskClient, inspector)
+	err = policy.CheckSchemaCompatibility(ctx, app.Version, confRedis)
+	if err != nil {
+		return err
+	}
 	policySvc := policy.NewService(confRedis, queueSvc, conf.FromStorage)
 
 	replSvc := replication.New(queueSvc, verSvc, policySvc)

--- a/service/proxy/server.go
+++ b/service/proxy/server.go
@@ -97,6 +97,10 @@ func Start(ctx context.Context, app dom.AppInfo, conf *Config) error {
 	inspector := asynq.NewInspector(queueRedis)
 	defer inspector.Close()
 	queueSvc := tasks.NewQueueService(taskClient, inspector)
+	err = policy.CheckSchemaCompatibility(ctx, app.Version, confRedis)
+	if err != nil {
+		return err
+	}
 	policySvc := policy.NewService(confRedis, queueSvc, conf.Storage.Main())
 
 	metricsSvc := metrics.NewS3Service(conf.Metrics.Enabled)

--- a/service/worker/server.go
+++ b/service/worker/server.go
@@ -128,6 +128,10 @@ func Start(ctx context.Context, app dom.AppInfo, conf *Config) error {
 	inspector := asynq.NewInspector(queueRedis)
 	defer inspector.Close()
 	queueSvc := tasks.NewQueueService(taskClient, inspector)
+	err = policy.CheckSchemaCompatibility(ctx, app.Version, confRedis)
+	if err != nil {
+		return err
+	}
 	policySvc := policy.NewService(confRedis, queueSvc, conf.Storage.Main())
 
 	limiter := ratelimit.New(appRedis, conf.Storage.RateLimitConf())


### PR DESCRIPTION
## Pull Request

### Description

Main branch has changes in Redis schema incompatible with prevous releases. Check redis state and not start chorus services with legacy redis schema.
