### PR TITLE
Replication meta cleanup

### DIFF
--- a/pkg/dom/object.go
+++ b/pkg/dom/object.go
@@ -16,27 +16,8 @@
 
 package dom
 
-import (
-	"fmt"
-)
-
 type Object struct {
 	Bucket  string
 	Name    string
 	Version string
-}
-
-func (o Object) Key() string {
-	if o.Version == "" {
-		return fmt.Sprintf("%s:%s", o.Bucket, o.Name)
-	}
-	return fmt.Sprintf("%s:%s:%s", o.Bucket, o.Name, o.Version)
-}
-
-func (o Object) ACLKey() string {
-	return o.Key() + ":a"
-}
-
-func (o Object) TagKey() string {
-	return o.Key() + ":t"
 }

--- a/pkg/entity/migration.go
+++ b/pkg/entity/migration.go
@@ -65,18 +65,20 @@ func NewVersionedObjectID(storage string, bucket string, name string) VersionedO
 }
 
 type MigrationObjectID struct {
+	User        string
 	FromStorage string
-	FromBucket  string
 	ToStorage   string
+	FromBucket  string
 	ToBucket    string
 	Prefix      string
 }
 
-func NewMigrationObjectID(fromStorage string, fromBucket string, toStorage string, toBucket string, prefix string) MigrationObjectID {
+func NewMigrationObjectID(user string, fromStorage string, fromBucket string, toStorage string, toBucket string, prefix string) MigrationObjectID {
 	return MigrationObjectID{
+		User:        user,
 		FromStorage: fromStorage,
-		FromBucket:  fromBucket,
 		ToStorage:   toStorage,
+		FromBucket:  fromBucket,
 		ToBucket:    toBucket,
 		Prefix:      prefix,
 	}
@@ -85,6 +87,7 @@ func NewMigrationObjectID(fromStorage string, fromBucket string, toStorage strin
 func NewMigrationObjectIDFromUniversalReplicationID(replicationID UniversalReplicationID, bucket string, prefix string) MigrationObjectID {
 	fromBucket, toBucket := replicationID.FromToBuckets(bucket)
 	return MigrationObjectID{
+		User:        replicationID.user,
 		FromStorage: replicationID.fromStorage,
 		FromBucket:  fromBucket,
 		ToStorage:   replicationID.toStorage,
@@ -96,9 +99,10 @@ func NewMigrationObjectIDFromUniversalReplicationID(replicationID UniversalRepli
 func NewNonRecursiveMigrationObjectIDFromUniversalReplicationID(replicationID UniversalReplicationID, bucket string) MigrationObjectID {
 	fromBucket, toBucket := replicationID.FromToBuckets(bucket)
 	return MigrationObjectID{
+		User:        replicationID.user,
 		FromStorage: replicationID.fromStorage,
-		FromBucket:  fromBucket,
 		ToStorage:   replicationID.toStorage,
+		FromBucket:  fromBucket,
 		ToBucket:    toBucket,
 	}
 }
@@ -106,8 +110,8 @@ func NewNonRecursiveMigrationObjectIDFromUniversalReplicationID(replicationID Un
 type MigrationBucketID struct {
 	User        string
 	FromStorage string
-	FromBucket  string
 	ToStorage   string
+	FromBucket  string
 	ToBucket    string
 }
 
@@ -115,8 +119,8 @@ func NewMigrationBucketIDFromUniversalReplicationID(replicationID UniversalRepli
 	return MigrationBucketID{
 		User:        replicationID.user,
 		FromStorage: replicationID.fromStorage,
-		FromBucket:  replicationID.fromBucket,
 		ToStorage:   replicationID.toStorage,
+		FromBucket:  replicationID.fromBucket,
 		ToBucket:    replicationID.toBucket,
 	}
 }

--- a/pkg/entity/replication_id.go
+++ b/pkg/entity/replication_id.go
@@ -98,9 +98,9 @@ func (r *UniversalReplicationID) FromToBuckets(taskBucket string) (from, to stri
 		// should never happen
 		panic(fmt.Sprintf("trying to access empty replication ID: %#v", *r))
 	}
-	if taskBucket != r.fromBucket {
+	if taskBucket != r.fromBucket && taskBucket != r.toBucket {
 		// should never happen
-		panic(fmt.Sprintf("task bucket %q does not match replication from bucket %q", taskBucket, r.fromBucket))
+		panic(fmt.Sprintf("task bucket %q does not match replication buckets %q-%q", taskBucket, r.fromBucket, r.toBucket))
 	}
 	// bucket replication
 	return r.fromBucket, r.toBucket

--- a/pkg/entity/replication_id_test.go
+++ b/pkg/entity/replication_id_test.go
@@ -34,21 +34,7 @@ func TestIDFromBucketReplication(t *testing.T) {
 			wantPanic: false,
 		},
 		{
-			name: "invalid bucket is not equal to from bucket",
-			args: args{
-				id: BucketReplicationPolicy{
-					User:        "u",
-					FromStorage: "fs",
-					FromBucket:  "fb",
-					ToStorage:   "ts",
-					ToBucket:    "tb",
-				},
-				bucket: "tb",
-			},
-			wantPanic: true,
-		},
-		{
-			name: "invalid bucket is not equal to from bucket",
+			name: "invalid bucket is not equal to from/to bucket",
 			args: args{
 				id: BucketReplicationPolicy{
 					User:        "u",
@@ -62,7 +48,7 @@ func TestIDFromBucketReplication(t *testing.T) {
 			wantPanic: true,
 		},
 		{
-			name: "invalid bucket is not equal to from bucket",
+			name: "invalid bucket is not equal to from/to bucket",
 			args: args{
 				id: BucketReplicationPolicy{
 					User:        "u",

--- a/pkg/meta/version_keys.go
+++ b/pkg/meta/version_keys.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Clyso GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meta
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/clyso/chorus/pkg/dom"
+	"github.com/clyso/chorus/pkg/entity"
+)
+
+type versionKind string
+
+const (
+	payload versionKind = "p"
+	acl     versionKind = "a"
+	tags    versionKind = "t"
+)
+
+var kinds = []versionKind{acl, payload, tags}
+
+// Version meta Redis schema:
+//
+// Versions are stored in per-bucket Redis hashes, where:
+// Key: v:<user_id>:<from_storage>:<to_storage>:<from_bucket>:<to_bucket>
+// Fields:
+// {f|t}:[<obj_id>]:{p|a|t} -> <int_version>
+// ^from/to ^object    ^(payload|acl|tags)
+//
+// Q: why per-bucket hash instead of per-replicationID hash?
+//
+//	Pros: lower memory usage for user replication: no bucket name if hash fields for objects
+//	Cons: must use SCAN prefix MATCH to delete all metadata for user replication
+//
+// Motivation:
+//
+//	avg(buckets per user) << avg(objects per bucket) => big memory savings & small scan overhead => per-bucket hash
+//
+// Example hash:
+//
+// v:user1:storage1:storage2:bucket1:bucket1 -> {
+//
+//	 "f::t": 5,              # from bucket1 tags version
+//	 "t::t": 3,              # to   bucket1 tags version
+//	 "f::a": 2,              # from bucket1 acl version
+//	 "t::a": 4,              # to   bucket1 acl version
+//	 "f:obj1:p": 10,         # from bucket1/obj1 payload version
+//	 "t:obj1:p": 8,          # to   bucket1/obj1 payload version
+//	 "f:obj1:t": 10,         # from bucket1/obj1 tags version
+//	 "t:obj1:t": 8,          # to   bucket1/obj1 tags version
+//	 ...
+//	}
+type redisKeys struct {
+	hashKey   string
+	fromField string
+	toField   string
+}
+
+func toRedisKeys(replID entity.UniversalReplicationID, bucket, objectID string, kind versionKind) redisKeys {
+	fromBucket, toBucket := replID.FromToBuckets(bucket)
+	return redisKeys{
+		hashKey:   fmt.Sprintf("v:%s:%s:%s:%s:%s", replID.User(), replID.FromStorage(), replID.ToStorage(), fromBucket, toBucket),
+		fromField: fmt.Sprintf("f:%s:%s", objectID, kind),
+		toField:   fmt.Sprintf("t:%s:%s", objectID, kind),
+	}
+}
+
+// returns Redis MATCH key pattern
+func redisReplicationMATCH(replID entity.UniversalReplicationID) string {
+	if bucketID, ok := replID.AsBucketID(); ok {
+		// exact match for single HASH of bucket replication
+		return fmt.Sprintf("v:%s:%s:%s:%s:%s", replID.User(), replID.FromStorage(), replID.ToStorage(), bucketID.FromBucket, bucketID.ToBucket)
+	}
+	// wildcard match for all HASHES of user replication
+	return fmt.Sprintf("v:%s:%s:%s:*", replID.User(), replID.FromStorage(), replID.ToStorage())
+}
+
+func toRedisBucketKeys(replID entity.UniversalReplicationID, bucket string, kind versionKind) (redisKeys, error) {
+	if bucket == "" {
+		return redisKeys{}, fmt.Errorf("%w: bucket name is required for bucket version", dom.ErrInvalidArg)
+	}
+	if !slices.Contains(kinds, kind) {
+		return redisKeys{}, fmt.Errorf("%w: invalid bucket version kind %q", dom.ErrInvalidArg, kind)
+	}
+	return toRedisKeys(replID, bucket, "", kind), nil
+}
+
+func toRedisObjKeys(replID entity.UniversalReplicationID, object dom.Object, kind versionKind) (redisKeys, error) {
+	bucket, objectID := object.Bucket, objectID(object)
+	if bucket == "" {
+		return redisKeys{}, fmt.Errorf("%w: bucket name is required for object version", dom.ErrInvalidArg)
+	}
+	if objectID == "" {
+		return redisKeys{}, fmt.Errorf("%w: object ID is required for object version", dom.ErrInvalidArg)
+	}
+	if !slices.Contains(kinds, kind) {
+		return redisKeys{}, fmt.Errorf("%w: invalid object version kind %q", dom.ErrInvalidArg, kind)
+	}
+	return toRedisKeys(replID, bucket, objectID, kind), nil
+}
+
+// provides unique ID for versioning objects
+func objectID(obj dom.Object) string {
+	if obj.Version == "" {
+		return obj.Name
+	}
+	return obj.Name + obj.Version
+}
+
+func allRedisObjKeys(replID entity.UniversalReplicationID, object dom.Object) (key string, fields []string, err error) {
+	fields = make([]string, 0, len(kinds)*2)
+	for _, kind := range kinds {
+		objKeys, err := toRedisObjKeys(replID, object, kind)
+		if err != nil {
+			return "", nil, err
+		}
+		key = objKeys.hashKey
+		fields = append(fields, objKeys.fromField, objKeys.toField)
+	}
+	return key, fields, nil
+}
+
+func allRedisBucketKeys(replID entity.UniversalReplicationID, bucket string) (key string, fields []string, err error) {
+	fields = make([]string, 0, len(kinds)*2)
+	for _, kind := range kinds {
+		objKeys, err := toRedisBucketKeys(replID, bucket, kind)
+		if err != nil {
+			return "", nil, err
+		}
+		key = objKeys.hashKey
+		fields = append(fields, objKeys.fromField, objKeys.toField)
+	}
+	return key, fields, nil
+}

--- a/pkg/meta/version_keys_test.go
+++ b/pkg/meta/version_keys_test.go
@@ -1,0 +1,397 @@
+package meta
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/clyso/chorus/pkg/dom"
+	"github.com/clyso/chorus/pkg/entity"
+)
+
+func Test_redisReplicationMATCH(t *testing.T) {
+	type args struct {
+		replID entity.UniversalReplicationID
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "bucket replication",
+			args: args{
+				replID: entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					FromBucket:  "bucket1",
+					ToStorage:   "storage2",
+					ToBucket:    "bucket2",
+				}),
+			},
+			want: "v:user1:storage1:storage2:bucket1:bucket2",
+		},
+		{
+			name: "user replication",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage1",
+				}),
+			},
+			want: "v:user1:storage1:storage1:*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redisReplicationMATCH(tt.args.replID); got != tt.want {
+				t.Errorf("redisReplicationMATCH() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_toRedisKeys(t *testing.T) {
+	type args struct {
+		replID   entity.UniversalReplicationID
+		bucket   string
+		objectID string
+		kind     versionKind
+	}
+	tests := []struct {
+		name string
+		args args
+		want redisKeys
+	}{
+		{
+			name: "bucket payload for bucket replication",
+			args: args{
+				replID: entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					FromBucket:  "bucket1",
+					ToStorage:   "storage2",
+					ToBucket:    "bucket2",
+				}),
+				bucket:   "bucket1",
+				objectID: "",
+				kind:     payload,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket2",
+				fromField: "f::p",
+				toField:   "t::p",
+			},
+		},
+		{
+			name: "bucket payload for user replication",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				bucket:   "bucket1",
+				objectID: "",
+				kind:     payload,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket1",
+				fromField: "f::p",
+				toField:   "t::p",
+			},
+		},
+		{
+			name: "object tags for bucket replication",
+			args: args{
+				replID: entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					FromBucket:  "bucket1",
+					ToStorage:   "storage2",
+					ToBucket:    "bucket2",
+				}),
+				bucket:   "bucket1",
+				objectID: "obj1",
+				kind:     tags,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket2",
+				fromField: "f:obj1:t",
+				toField:   "t:obj1:t",
+			},
+		},
+		{
+			name: "object acl for user replication",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				bucket:   "bucket1",
+				objectID: "obj1",
+				kind:     acl,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket1",
+				fromField: "f:obj1:a",
+				toField:   "t:obj1:a",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toRedisKeys(tt.args.replID, tt.args.bucket, tt.args.objectID, tt.args.kind); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toRedisKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_toRedisBucketKeys(t *testing.T) {
+	type args struct {
+		replID entity.UniversalReplicationID
+		bucket string
+		kind   versionKind
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    redisKeys
+		wantErr bool
+	}{
+		{
+			name: "bucket tags for bucket replication",
+			args: args{
+				replID: entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					FromBucket:  "bucket1",
+					ToStorage:   "storage2",
+					ToBucket:    "bucket2",
+				}),
+				bucket: "bucket1",
+				kind:   tags,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket2",
+				fromField: "f::t",
+				toField:   "t::t",
+			},
+			wantErr: false,
+		},
+		{
+			name: "bucket acl for user replication",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				bucket: "bucket1",
+				kind:   acl,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket1",
+				fromField: "f::a",
+				toField:   "t::a",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing bucket name",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				bucket: "",
+				kind:   payload,
+			},
+			want:    redisKeys{},
+			wantErr: true,
+		},
+		{
+			name: "invalid version kind",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User: "user1",
+
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				bucket: "bucket1",
+				kind:   "invalid_kind",
+			},
+			want:    redisKeys{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toRedisBucketKeys(tt.args.replID, tt.args.bucket, tt.args.kind)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("toRedisBucketKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toRedisBucketKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_toRedisObjKeys(t *testing.T) {
+	type args struct {
+		replID entity.UniversalReplicationID
+		object dom.Object
+		kind   versionKind
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    redisKeys
+		wantErr bool
+	}{
+		{
+			name: "object payload for bucket replication",
+			args: args{
+				replID: entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					FromBucket:  "bucket1",
+					ToStorage:   "storage2",
+					ToBucket:    "bucket2",
+				}),
+				object: dom.Object{
+					Bucket:  "bucket1",
+					Name:    "obj1",
+					Version: "",
+				},
+				kind: payload,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket2",
+				fromField: "f:obj1:p",
+				toField:   "t:obj1:p",
+			},
+			wantErr: false,
+		},
+		{
+			name: "object tags for user replication",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				object: dom.Object{
+					Bucket:  "bucket1",
+					Name:    "obj1",
+					Version: "",
+				},
+				kind: tags,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket1",
+				fromField: "f:obj1:t",
+				toField:   "t:obj1:t",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing bucket name",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				object: dom.Object{
+					Bucket:  "",
+					Name:    "obj1",
+					Version: "",
+				},
+				kind: payload,
+			},
+			want:    redisKeys{},
+			wantErr: true,
+		},
+		{
+			name: "missing object ID",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				object: dom.Object{
+					Bucket:  "bucket1",
+					Name:    "",
+					Version: "",
+				},
+				kind: acl,
+			},
+			want:    redisKeys{},
+			wantErr: true,
+		},
+		{
+			name: "invalid version kind",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				object: dom.Object{
+					Bucket:  "bucket1",
+					Name:    "obj1",
+					Version: "",
+				},
+				kind: "invalid_kind",
+			},
+			want:    redisKeys{},
+			wantErr: true,
+		},
+		{
+			name: "object with version specified",
+			args: args{
+				replID: entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+					User:        "user1",
+					FromStorage: "storage1",
+					ToStorage:   "storage2",
+				}),
+				object: dom.Object{
+					Bucket:  "bucket1",
+					Name:    "obj1",
+					Version: "v1",
+				},
+				kind: payload,
+			},
+			want: redisKeys{
+				hashKey:   "v:user1:storage1:storage2:bucket1:bucket1",
+				fromField: "f:obj1v1:p",
+				toField:   "t:obj1v1:p",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toRedisObjKeys(tt.args.replID, tt.args.object, tt.args.kind)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("toRedisObjKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("toRedisObjKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/meta/version_service_test.go
+++ b/pkg/meta/version_service_test.go
@@ -17,552 +17,686 @@
 package meta
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/clyso/chorus/pkg/dom"
+	"github.com/clyso/chorus/pkg/entity"
 	"github.com/clyso/chorus/pkg/testutil"
 )
 
-func Test_Version_svc(t *testing.T) {
+func Test_Version_e2e(t *testing.T) {
 	r := require.New(t)
 	c := testutil.SetupRedis(t)
-
 	s := NewVersionService(c)
+	ctx := t.Context()
 
-	obj := dom.Object{
-		Bucket:  "bucket",
-		Name:    "obj",
-		Version: "",
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	vers, err := s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-
-	stor := Destination("stor1")
-	err = s.UpdateIfGreater(ctx, obj, stor, -1)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateIfGreater(ctx, obj, stor, 0)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateIfGreater(ctx, obj, stor, 69)
-	r.ErrorIs(err, dom.ErrNotFound)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	incVer, err := s.IncrementObj(ctx, obj, stor)
-	r.NoError(err)
-	r.EqualValues(1, incVer)
-	err = s.UpdateIfGreater(ctx, obj, stor, 69)
-	r.NoError(err)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(69, vers[stor])
-
-	err = s.UpdateIfGreater(ctx, obj, stor, 67)
-	r.ErrorIs(err, dom.ErrAlreadyExists)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(69, vers[stor])
-	err = s.UpdateIfGreater(ctx, obj, stor, 0)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateIfGreater(ctx, obj, stor, 420)
-	r.NoError(err)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(420, vers[stor])
-
-	incVer, err = s.IncrementObj(ctx, obj, stor)
-	r.NoError(err)
-	r.EqualValues(421, incVer)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(421, vers[stor])
-
-	stor2 := Destination("stor2")
-	incVer2, err := s.IncrementObj(ctx, obj, stor2)
-	r.NoError(err)
-	r.EqualValues(422, incVer2)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 2)
-	r.EqualValues(421, vers[stor])
-	r.EqualValues(422, vers[stor2])
-
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-
-	err = s.DeleteObjAll(ctx, obj)
-	r.NoError(err)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-
-	err = s.UpdateACLIfGreater(ctx, obj, stor, -1)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateACLIfGreater(ctx, obj, stor, 0)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateACLIfGreater(ctx, obj, stor, 33)
-	r.ErrorIs(err, dom.ErrNotFound)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-
-	aclVer, err := s.IncrementACL(ctx, obj, stor)
-	r.NoError(err)
-	r.EqualValues(1, aclVer)
-	err = s.UpdateACLIfGreater(ctx, obj, stor, 33)
-	r.NoError(err)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(33, vers[stor])
-
-	err = s.UpdateACLIfGreater(ctx, obj, stor, 32)
-	r.ErrorIs(err, dom.ErrAlreadyExists)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(33, vers[stor])
-	err = s.UpdateACLIfGreater(ctx, obj, stor, 0)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateACLIfGreater(ctx, obj, stor, 55)
-	r.NoError(err)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(55, vers[stor])
-
-	aclVer, err = s.IncrementACL(ctx, obj, stor)
-	r.NoError(err)
-	r.EqualValues(56, aclVer)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 1)
-	r.EqualValues(56, vers[stor])
-
-	aclVer2, err := s.IncrementACL(ctx, obj, stor2)
-	r.NoError(err)
-	r.EqualValues(57, aclVer2)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 2)
-	r.EqualValues(57, vers[stor2])
-
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, -1)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, 0)
-	r.ErrorIs(err, dom.ErrInvalidArg)
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, 33)
-	r.ErrorIs(err, dom.ErrNotFound)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-
-	tagVer, err := s.IncrementTags(ctx, obj, stor)
-	r.NoError(err)
-	r.EqualValues(1, tagVer)
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, 33)
-	r.NoError(err)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(33, vers[stor])
-
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, 32)
-	r.ErrorIs(err, dom.ErrAlreadyExists)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(33, vers[stor])
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, 0)
-	r.Error(err)
-	err = s.UpdateTagsIfGreater(ctx, obj, stor, 55)
-	r.NoError(err)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.EqualValues(55, vers[stor])
-
-	tagVer, err = s.IncrementTags(ctx, obj, stor)
-	r.NoError(err)
-	r.EqualValues(56, tagVer)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 1)
-	r.EqualValues(56, vers[stor])
-
-	tagVer2, err := s.IncrementTags(ctx, obj, stor2)
-	r.NoError(err)
-	r.EqualValues(57, tagVer2)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 2)
-	r.EqualValues(57, vers[stor2])
-
-	err = s.DeleteObjAll(ctx, obj)
-	r.NoError(err)
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetTags(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-	vers, err = s.GetACL(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-}
-
-func Test_inc_version_during_switch(t *testing.T) {
 	var (
-		stor1   = Destination("stor1")
-		stor2   = Destination("stor2")
-		stor3   = Destination("stor3")
-		buck    = "buck"
-		objName = "object"
-		obj     = dom.Object{
-			Bucket:  buck,
-			Name:    objName,
+		replB1 = entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+			User:        "user1",
+			FromStorage: "stor1",
+			FromBucket:  "bucket",
+			ToStorage:   "stor2",
+			ToBucket:    "bucket",
+		})
+
+		replB2 = entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+			User:        "user1",
+			FromStorage: "stor2",
+			FromBucket:  "bucket",
+			ToStorage:   "stor1",
+			ToBucket:    "bucket2",
+		})
+
+		replU1 = entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+			User:        "user2",
+			FromStorage: "stor1",
+			ToStorage:   "stor2",
+		})
+
+		replU2 = entity.UniversalFromUserReplication(entity.UserReplicationPolicy{
+			User:        "user3",
+			FromStorage: "stor1",
+			ToStorage:   "stor2",
+		})
+
+		obj1 = dom.Object{
+			Bucket:  "bucket",
+			Name:    "obj1",
 			Version: "",
 		}
-		ctx = context.Background()
+
+		obj2 = dom.Object{
+			Bucket:  "bucket",
+			Name:    "obj2",
+			Version: "",
+		}
+
+		replsU = []entity.UniversalReplicationID{replU1, replU2}
+		replsB = []entity.UniversalReplicationID{replB1, replB2}
+		repls  = append(replsU, replsB...)
+		objs   = []dom.Object{obj1, obj2}
+
+		bucket = "bucket"
+
+		emptyVer Version
 	)
+
+	// check that all versions are zero initially
+	for _, rID := range repls {
+		for _, obj := range objs {
+			ver, err := s.GetObj(ctx, rID, obj)
+			r.NoError(err)
+			r.Equal(emptyVer, ver)
+
+			ver, err = s.GetTags(ctx, rID, obj)
+			r.NoError(err)
+			r.Equal(emptyVer, ver)
+
+			ver, err = s.GetACL(ctx, rID, obj)
+			r.NoError(err)
+			r.Equal(emptyVer, ver)
+		}
+		ver, err := s.GetBucket(ctx, rID, bucket)
+		r.NoError(err)
+		r.Equal(emptyVer, ver)
+
+		ver, err = s.GetBucketTags(ctx, rID, bucket)
+		r.NoError(err)
+		r.Equal(emptyVer, ver)
+
+		ver, err = s.GetBucketACL(ctx, rID, bucket)
+		r.NoError(err)
+		r.Equal(emptyVer, ver)
+	}
+
+	// increment every version different amount of times
+	n := 0
+	for _, rID := range repls {
+		for _, obj := range objs {
+			dest := Destination{
+				Storage: rID.FromStorage(),
+				Bucket:  obj.Bucket,
+			}
+
+			n++
+			for i := 1; i <= n; i++ {
+				incVer, err := s.IncrementObj(ctx, rID, obj, dest)
+				r.NoError(err)
+				r.EqualValues(i, incVer)
+			}
+			n++
+			for i := 1; i <= n; i++ {
+				incVer, err := s.IncrementTags(ctx, rID, obj, dest)
+				r.NoError(err)
+				r.EqualValues(i, incVer)
+			}
+			n++
+			for i := 1; i <= n; i++ {
+				incVer, err := s.IncrementACL(ctx, rID, obj, dest)
+				r.NoError(err)
+				r.EqualValues(i, incVer)
+			}
+		}
+		dest := Destination{
+			Storage: rID.FromStorage(),
+			Bucket:  bucket,
+		}
+
+		n++
+		for i := 1; i <= n; i++ {
+			incVer, err := s.IncrementBucket(ctx, rID, bucket, dest)
+			r.NoError(err)
+			r.EqualValues(i, incVer)
+		}
+		n++
+		for i := 1; i <= n; i++ {
+			incVer, err := s.IncrementBucketTags(ctx, rID, bucket, dest)
+			r.NoError(err)
+			r.EqualValues(i, incVer)
+		}
+		n++
+		for i := 1; i <= n; i++ {
+			incVer, err := s.IncrementBucketACL(ctx, rID, bucket, dest)
+			r.NoError(err)
+			r.EqualValues(i, incVer)
+		}
+	}
+
+	// check that all versions are as expected
+	// and set to version = from version
+	n = 0
+	for _, rID := range repls {
+		for _, obj := range objs {
+			_, toBucket := rID.FromToBuckets(obj.Bucket)
+			dest := Destination{
+				Storage: rID.ToStorage(),
+				Bucket:  toBucket,
+			}
+
+			n++
+			ver, err := s.GetObj(ctx, rID, obj)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.Zero(ver.To)
+			// set to version = from
+			err = s.UpdateIfGreater(ctx, rID, obj, dest, ver.From)
+			r.NoError(err)
+
+			n++
+			ver, err = s.GetTags(ctx, rID, obj)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.Zero(ver.To)
+			// set to version = from
+			err = s.UpdateTagsIfGreater(ctx, rID, obj, dest, ver.From)
+			r.NoError(err)
+
+			n++
+			ver, err = s.GetACL(ctx, rID, obj)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.Zero(ver.To)
+			// set to version = from
+			err = s.UpdateACLIfGreater(ctx, rID, obj, dest, ver.From)
+			r.NoError(err)
+		}
+		_, toBucket := rID.FromToBuckets(bucket)
+		dest := Destination{
+			Storage: rID.ToStorage(),
+			Bucket:  toBucket,
+		}
+
+		n++
+		ver, err := s.GetBucket(ctx, rID, bucket)
+		r.NoError(err)
+		r.EqualValues(n, ver.From)
+		r.Zero(ver.To)
+		// set to version = from
+		err = s.UpdateBucketIfGreater(ctx, rID, bucket, dest, ver.From)
+		r.NoError(err)
+
+		n++
+		ver, err = s.GetBucketTags(ctx, rID, bucket)
+		r.NoError(err)
+		r.EqualValues(n, ver.From)
+		r.Zero(ver.To)
+		// set to version = from
+		err = s.UpdateBucketTagsIfGreater(ctx, rID, bucket, dest, ver.From)
+		r.NoError(err)
+
+		n++
+		ver, err = s.GetBucketACL(ctx, rID, bucket)
+		r.NoError(err)
+		r.EqualValues(n, ver.From)
+		r.Zero(ver.To)
+		// set to version = from
+		err = s.UpdateBucketACLIfGreater(ctx, rID, bucket, dest, ver.From)
+		r.NoError(err)
+	}
+
+	// check from/to versions
+	n = 0
+	for _, rID := range repls {
+		for _, obj := range objs {
+			n++
+			ver, err := s.GetObj(ctx, rID, obj)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.EqualValues(n, ver.To)
+
+			n++
+			ver, err = s.GetTags(ctx, rID, obj)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.EqualValues(n, ver.To)
+
+			n++
+			ver, err = s.GetACL(ctx, rID, obj)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.EqualValues(n, ver.To)
+		}
+
+		n++
+		ver, err := s.GetBucket(ctx, rID, bucket)
+		r.NoError(err)
+		r.EqualValues(n, ver.From)
+		r.EqualValues(n, ver.To)
+
+		n++
+		ver, err = s.GetBucketTags(ctx, rID, bucket)
+		r.NoError(err)
+		r.EqualValues(n, ver.From)
+		r.EqualValues(n, ver.To)
+
+		n++
+		ver, err = s.GetBucketACL(ctx, rID, bucket)
+		r.NoError(err)
+		r.EqualValues(n, ver.From)
+	}
+
+	// delete replciation versions one by one and check that the rest remain unchanged
+	n = 0
+	for i, rID := range repls {
+		// delete repl meta
+		err := s.Cleanup(ctx, rID)
+		r.NoError(err)
+
+		n = 0
+		// check deleted repl version are empty now
+		for _, obj := range objs {
+			n++
+			ver, err := s.GetObj(ctx, rID, obj)
+			r.NoError(err)
+			r.Equal(emptyVer, ver)
+
+			n++
+			ver, err = s.GetTags(ctx, rID, obj)
+			r.NoError(err)
+			r.Equal(emptyVer, ver)
+
+			n++
+			ver, err = s.GetACL(ctx, rID, obj)
+			r.NoError(err)
+			r.Equal(emptyVer, ver)
+		}
+		n++
+		ver, err := s.GetBucket(ctx, rID, bucket)
+		r.NoError(err)
+		r.Equal(emptyVer, ver)
+
+		n++
+		ver, err = s.GetBucketTags(ctx, rID, bucket)
+		r.NoError(err)
+		r.Equal(emptyVer, ver)
+
+		n++
+		ver, err = s.GetBucketACL(ctx, rID, bucket)
+		r.NoError(err)
+		r.Equal(emptyVer, ver)
+
+		n *= i + 1
+		// check remaining repls unchanged
+		n = (i + 1) * (len(objs)*3 + 3)
+		for _, rID := range repls[i+1:] {
+			for _, obj := range objs {
+				n++
+				ver, err := s.GetObj(ctx, rID, obj)
+				r.NoError(err)
+				r.EqualValues(n, ver.From)
+				r.EqualValues(n, ver.To)
+
+				n++
+				ver, err = s.GetTags(ctx, rID, obj)
+				r.NoError(err)
+				r.EqualValues(n, ver.From)
+				r.EqualValues(n, ver.To)
+
+				n++
+				ver, err = s.GetACL(ctx, rID, obj)
+				r.NoError(err)
+				r.EqualValues(n, ver.From)
+				r.EqualValues(n, ver.To)
+			}
+
+			n++
+			ver, err := s.GetBucket(ctx, rID, bucket)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.EqualValues(n, ver.To)
+
+			n++
+			ver, err = s.GetBucketTags(ctx, rID, bucket)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+			r.EqualValues(n, ver.To)
+
+			n++
+			ver, err = s.GetBucketACL(ctx, rID, bucket)
+			r.NoError(err)
+			r.EqualValues(n, ver.From)
+		}
+	}
+}
+
+func Test_Version(t *testing.T) {
 	r := require.New(t)
 	c := testutil.SetupRedis(t)
 	s := NewVersionService(c)
+	ctx := t.Context()
 
-	vers, err := s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Empty(vers)
-
-	ver, err := s.IncrementObj(ctx, obj, stor1)
-	r.NoError(err)
-	r.EqualValues(1, ver)
-
-	ver, err = s.IncrementObj(ctx, obj, stor2)
-	r.NoError(err)
-	r.EqualValues(2, ver)
-	ver, err = s.IncrementObj(ctx, obj, stor2)
-	r.NoError(err)
-	r.EqualValues(3, ver)
-
-	ver, err = s.IncrementObj(ctx, obj, stor3)
-	r.NoError(err)
-	r.EqualValues(4, ver)
-	ver, err = s.IncrementObj(ctx, obj, stor3)
-	r.NoError(err)
-	r.EqualValues(5, ver)
-	ver, err = s.IncrementObj(ctx, obj, stor3)
-	r.NoError(err)
-	r.EqualValues(6, ver)
-
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 3)
-	r.EqualValues(1, vers[stor1])
-	r.EqualValues(3, vers[stor2])
-	r.EqualValues(6, vers[stor3])
-
-	ver, err = s.IncrementObj(ctx, obj, stor1)
-	r.NoError(err)
-	r.EqualValues(7, ver)
-
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 3)
-	r.EqualValues(7, vers[stor1])
-	r.EqualValues(3, vers[stor2])
-	r.EqualValues(6, vers[stor3])
-
-	ver, err = s.IncrementObj(ctx, obj, stor2)
-	r.NoError(err)
-	r.EqualValues(8, ver)
-
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 3)
-	r.EqualValues(7, vers[stor1])
-	r.EqualValues(8, vers[stor2])
-	r.EqualValues(6, vers[stor3])
-
-	ver, err = s.IncrementObj(ctx, obj, stor3)
-	r.NoError(err)
-	r.EqualValues(9, ver)
-
-	vers, err = s.GetObj(ctx, obj)
-	r.NoError(err)
-	r.Len(vers, 3)
-	r.EqualValues(7, vers[stor1])
-	r.EqualValues(8, vers[stor2])
-	r.EqualValues(9, vers[stor3])
-}
-
-func Test_DeleteBucketMeta(t *testing.T) {
-	// setup
-	r := require.New(t)
-	c := testutil.SetupRedis(t)
-
-	s := NewVersionService(c)
-
-	s1, s2 := Destination("stor1"), Destination("stor2")
-	b1, b2 := "buck1", "buck2"
-	o1, o2, o3, o4 := dom.Object{
-		Bucket: b1,
-		Name:   "obj1",
-	}, dom.Object{
-		Bucket: b1,
-		Name:   "obj2",
-	}, dom.Object{
-		Bucket: b2,
-		Name:   "obj1",
-	}, dom.Object{
-		Bucket: b2,
-		Name:   "obj2",
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	// add version metadata for all storage/bucket/obj combinations
-	s.IncrementBucket(ctx, b1, s1)
-	s.IncrementBucket(ctx, b1, s2)
-	s.IncrementBucket(ctx, b2, s1)
-	s.IncrementBucket(ctx, b2, s2)
-
-	s.IncrementBucketACL(ctx, b1, s1)
-	s.IncrementBucketACL(ctx, b1, s2)
-	s.IncrementBucketACL(ctx, b2, s1)
-	s.IncrementBucketACL(ctx, b2, s2)
-
-	s.IncrementBucketTags(ctx, b1, s1)
-	s.IncrementBucketTags(ctx, b1, s2)
-	s.IncrementBucketTags(ctx, b2, s1)
-	s.IncrementBucketTags(ctx, b2, s2)
-
-	s.IncrementObj(ctx, o1, s1)
-	s.IncrementObj(ctx, o1, s2)
-	s.IncrementObj(ctx, o2, s1)
-	s.IncrementObj(ctx, o2, s2)
-	s.IncrementObj(ctx, o3, s1)
-	s.IncrementObj(ctx, o3, s2)
-	s.IncrementObj(ctx, o4, s1)
-	s.IncrementObj(ctx, o4, s2)
-
-	s.IncrementACL(ctx, o1, s1)
-	s.IncrementACL(ctx, o1, s2)
-	s.IncrementACL(ctx, o2, s1)
-	s.IncrementACL(ctx, o2, s2)
-	s.IncrementACL(ctx, o3, s1)
-	s.IncrementACL(ctx, o3, s2)
-	s.IncrementACL(ctx, o4, s1)
-	s.IncrementACL(ctx, o4, s2)
-
-	s.IncrementTags(ctx, o1, s1)
-	s.IncrementTags(ctx, o1, s2)
-	s.IncrementTags(ctx, o2, s1)
-	s.IncrementTags(ctx, o2, s2)
-	s.IncrementTags(ctx, o3, s1)
-	s.IncrementTags(ctx, o3, s2)
-	s.IncrementTags(ctx, o4, s1)
-	s.IncrementTags(ctx, o4, s2)
-
-	// delete bucket meta only for storage s1 and bucket b1
-	s.DeleteBucketMeta(ctx, s1, b1)
-
-	// check that that version metadata only for s1&b1 combiantion was removed (version is zero)
-	// and the rest of metadata remained the same
-	ver, err := s.GetObj(ctx, o1)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetObj(ctx, o2)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetObj(ctx, o3)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetObj(ctx, o4)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetACL(ctx, o1)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetACL(ctx, o2)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetACL(ctx, o3)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetACL(ctx, o4)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetTags(ctx, o1)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetTags(ctx, o2)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetTags(ctx, o3)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetTags(ctx, o4)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetBucket(ctx, b1)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetBucket(ctx, b2)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetBucketACL(ctx, b1)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetBucketACL(ctx, b2)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetBucketTags(ctx, b1)
-	r.NoError(err)
-	r.Zero(ver[s1])
-	r.EqualValues(2, ver[s2])
-
-	ver, err = s.GetBucketTags(ctx, b2)
-	r.NoError(err)
-	r.EqualValues(1, ver[s1])
-	r.EqualValues(2, ver[s2])
-}
-
-func TestDestination_Parse(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-	tests := []struct {
-		name        string
-		d           Destination
-		wantStorage string
-		wantBucket  *string
-	}{
-		{
-			name:        "only storage set",
-			d:           "abc",
-			wantStorage: "abc",
-			wantBucket:  nil,
-		},
-		{
-			name:        "nothing is set",
-			d:           "",
-			wantStorage: "",
-			wantBucket:  nil,
-		},
-		{
-			name:        "storage and bucket",
-			d:           "s:b",
-			wantStorage: "s",
-			wantBucket:  strPtr("b"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotStorage, gotBucket := tt.d.Parse()
-			if gotStorage != tt.wantStorage {
-				t.Errorf("Destination.Parse() gotStorage = %v, want %v", gotStorage, tt.wantStorage)
-			}
-			if gotBucket != tt.wantBucket {
-				if gotBucket == nil {
-					t.Errorf("Destination.Parse() gotBucket = %v, want %v", gotBucket, tt.wantBucket)
-				} else if tt.wantBucket == nil {
-					t.Errorf("Destination.Parse() gotBucket = %v, want %v", gotBucket, tt.wantBucket)
-
-				} else if *tt.wantBucket != *gotBucket {
-					t.Errorf("Destination.Parse() gotBucket = %s, want %s", *gotBucket, *tt.wantBucket)
-				}
-			}
+	var (
+		replID = entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+			User:        "user1",
+			FromStorage: "stor1",
+			FromBucket:  "bucket",
+			ToStorage:   "stor2",
+			ToBucket:    "bucket",
 		})
-	}
-}
 
-func TestToDest(t *testing.T) {
-	type args struct {
-		storage string
-		bucket  string
-	}
-	tests := []struct {
-		name string
-		args args
-		want Destination
-	}{
-		{
-			name: "empty",
-			args: args{
-				storage: "",
-				bucket:  "",
-			},
-			want: "",
-		},
-		{
-			name: "only storage",
-			args: args{
-				storage: "stor",
-				bucket:  "",
-			},
-			want: "stor",
-		},
-		{
-			name: "storage and bucket",
-			args: args{
-				storage: "stor",
-				bucket:  "buck",
-			},
-			want: "stor:buck",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ToDest(tt.args.storage, tt.args.bucket); got != tt.want {
-				t.Errorf("ToDest() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+		obj = dom.Object{
+			Bucket:  "bucket",
+			Name:    "obj1",
+			Version: "",
+		}
+
+		fromDest = Destination{
+			Storage: replID.FromStorage(),
+			Bucket:  obj.Bucket,
+		}
+
+		toDest = Destination{
+			Storage: replID.ToStorage(),
+			Bucket:  "bucket",
+		}
+	)
+
+	// check initial versions
+	ver, err := s.GetObj(ctx, replID, obj)
+	r.NoError(err, "no error for empty version")
+	r.Equal(Version{}, ver, "initial version is zero")
+
+	ver, err = s.GetTags(ctx, replID, obj)
+	r.NoError(err, "no error for empty tags version")
+	r.Equal(Version{}, ver, "initial tags version is zero")
+
+	ver, err = s.GetACL(ctx, replID, obj)
+	r.NoError(err, "no error for empty ACL version")
+	r.Equal(Version{}, ver, "initial ACL version is zero")
+
+	// test increments
+	incVer, err := s.IncrementObj(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment from version")
+	r.EqualValues(1, incVer, "from version incremented to 1")
+
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get version after increment")
+	r.EqualValues(1, ver.From, "from version incremented to 1")
+	r.EqualValues(0, ver.To, "to version is still zero")
+
+	incVer, err = s.IncrementObj(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment from version second time")
+	r.EqualValues(2, incVer, "from version incremented to 2")
+
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get version after second increment")
+	r.EqualValues(2, ver.From, "from version incremented to 2")
+	r.EqualValues(0, ver.To, "to version is still zero")
+
+	incVer, err = s.IncrementObj(ctx, replID, obj, toDest)
+	r.NoError(err, "increment to version")
+	r.EqualValues(3, incVer, "to version incremented to 3 = max(from,to)+1")
+
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get version after to increment")
+	r.EqualValues(2, ver.From, "from version is still 2")
+	r.EqualValues(3, ver.To, "to version incremented to 3")
+
+	// test UpdateIfGreater
+	wrongObj := dom.Object{Bucket: "bucket", Name: "asdfasdfasdfasdfasdfasdf", Version: ""}
+	err = s.UpdateIfGreater(ctx, replID, wrongObj, fromDest, 3)
+	r.ErrorIs(err, dom.ErrNotFound, "not fount error if hash not exists")
+
+	wrongReplID := entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+		User:        "userX",
+		FromStorage: "storX",
+		FromBucket:  "bucket",
+		ToStorage:   "stor2",
+		ToBucket:    "bucket",
+	})
+	err = s.UpdateIfGreater(ctx, wrongReplID, obj, toDest, 3)
+	r.ErrorIs(err, dom.ErrNotFound, "error when replication ID not found")
+
+	err = s.UpdateIfGreater(ctx, replID, obj, fromDest, 4)
+	r.ErrorIs(err, dom.ErrNotFound, "error when trying to set version more than other side")
+
+	err = s.UpdateIfGreater(ctx, replID, obj, fromDest, 1)
+	r.ErrorIs(err, dom.ErrAlreadyExists, "error when trying to set version less than current")
+
+	err = s.UpdateIfGreater(ctx, replID, obj, fromDest, 2)
+	r.ErrorIs(err, dom.ErrAlreadyExists, "error when trying to set version equal to current")
+
+	err = s.UpdateIfGreater(ctx, replID, obj, fromDest, 3)
+	r.NoError(err, "set from version to 3")
+
+	// inc versions for bucket
+	incVer, err = s.IncrementBucket(ctx, replID, obj.Bucket, fromDest)
+	r.NoError(err, "increment bucket from version")
+	r.EqualValues(1, incVer, "bucket from version incremented to 1")
+	ver, err = s.GetBucket(ctx, replID, obj.Bucket)
+	r.NoError(err, "get bucket version after increment")
+	r.EqualValues(1, ver.From, "bucket from version is 1")
+	r.EqualValues(0, ver.To, "bucket to version is 0")
+
+	//inc obj tags and acls
+	incVer, err = s.IncrementTags(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment tags from version")
+	r.EqualValues(1, incVer, "tags from version incremented to 1")
+	ver, err = s.GetTags(ctx, replID, obj)
+	r.NoError(err, "get object tags version after increment")
+	r.EqualValues(1, ver.From, "tags from version is 1")
+	r.EqualValues(0, ver.To, "tags to version is 0")
+
+	incVer, err = s.IncrementACL(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment ACL from version")
+	r.EqualValues(1, incVer, "ACL from version incremented to 1")
+	ver, err = s.GetACL(ctx, replID, obj)
+	r.NoError(err, "get object ACL version after increment")
+	r.EqualValues(1, ver.From, "ACL from version is 1")
+	r.EqualValues(0, ver.To, "ACL to version is 0")
+
+	// delete all object versions
+	err = s.DeleteObjAll(ctx, replID, obj)
+	r.NoError(err, "delete all object versions")
+
+	// check that all obj versions are zero and bucket version remains
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get object version after deletion")
+	r.Equal(Version{}, ver, "object version is zero after deletion")
+
+	ver, err = s.GetTags(ctx, replID, obj)
+	r.NoError(err, "get object tags version after deletion")
+	r.Equal(Version{}, ver, "object tags version is zero after deletion")
+
+	ver, err = s.GetACL(ctx, replID, obj)
+	r.NoError(err, "get object ACL version after deletion")
+	r.Equal(Version{}, ver, "object ACL version is zero after deletion")
+
+	ver, err = s.GetBucket(ctx, replID, obj.Bucket)
+	r.NoError(err, "get bucket version after object deletion")
+	r.EqualValues(1, ver.From, "bucket from version remains")
+	r.EqualValues(0, ver.To, "bucket to version remains zero")
+
+	// inc obj payload tags and acls again to verify they work after deletion
+	incVer, err = s.IncrementObj(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment object from version after deletion")
+	r.EqualValues(1, incVer, "object from version incremented to 1 after deletion")
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get object version after increment post-deletion")
+	r.EqualValues(1, ver.From, "object from version is 1 after deletion")
+	r.EqualValues(0, ver.To, "object to version is 0 after deletion")
+
+	incVer, err = s.IncrementTags(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment tags from version after deletion")
+	r.EqualValues(1, incVer, "tags from version incremented to 1 after deletion")
+	ver, err = s.GetTags(ctx, replID, obj)
+	r.NoError(err, "get object tags version after increment post-deletion")
+	r.EqualValues(1, ver.From, "tags from version is 1 after deletion")
+	r.EqualValues(0, ver.To, "tags to version is 0 after deletion")
+
+	incVer, err = s.IncrementACL(ctx, replID, obj, fromDest)
+	r.NoError(err, "increment ACL from version after deletion")
+	r.EqualValues(1, incVer, "ACL from version incremented to 1 after deletion")
+	ver, err = s.GetACL(ctx, replID, obj)
+	r.NoError(err, "get object ACL version after increment post-deletion")
+	r.EqualValues(1, ver.From, "ACL from version is 1 after deletion")
+	r.EqualValues(0, ver.To, "ACL to version is 0 after deletion")
+
+	//delete bucket versions
+	err = s.DeleteBucketAll(ctx, replID, obj.Bucket)
+	r.NoError(err, "delete all bucket versions")
+
+	// check that bucket versions are zero now
+	ver, err = s.GetBucket(ctx, replID, obj.Bucket)
+	r.NoError(err, "get bucket version after deletion")
+	r.Equal(Version{}, ver, "bucket version is zero after deletion")
+
+	//check that all object version remains unaffected
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get object version after bucket deletion")
+	r.EqualValues(1, ver.From, "object from version remains after bucket deletion")
+	r.EqualValues(0, ver.To, "object to version remains after bucket deletion")
+
+	ver, err = s.GetTags(ctx, replID, obj)
+	r.NoError(err, "get object tags version after bucket deletion")
+	r.EqualValues(1, ver.From, "object tags from version remains after bucket deletion")
+	r.EqualValues(0, ver.To, "object tags to version remains after bucket deletion")
+
+	ver, err = s.GetACL(ctx, replID, obj)
+	r.NoError(err, "get object ACL version after bucket deletion")
+	r.EqualValues(1, ver.From, "object ACL from version remains after bucket deletion")
+	r.EqualValues(0, ver.To, "object ACL to version remains after bucket deletion")
+
+	// add second replication versions to verify cleanup of multiple replications
+	replID2 := entity.UniversalFromBucketReplication(entity.BucketReplicationPolicy{
+		User:        "user1",
+		FromStorage: "stor1",
+		FromBucket:  "bucket",
+		ToStorage:   "stor3",
+		ToBucket:    "bucket",
+	})
+	// inc all obj/bucket versions for second replication
+	_, err = s.IncrementObj(ctx, replID2, obj, fromDest)
+	r.NoError(err, "increment object from version for second replication")
+
+	_, err = s.IncrementTags(ctx, replID2, obj, fromDest)
+	r.NoError(err, "increment tags from version for second replication")
+
+	_, err = s.IncrementACL(ctx, replID2, obj, fromDest)
+	r.NoError(err, "increment ACL from version for second replication")
+
+	_, err = s.IncrementBucket(ctx, replID2, obj.Bucket, fromDest)
+	r.NoError(err, "increment bucket from version for second replication")
+
+	_, err = s.IncrementBucketTags(ctx, replID2, obj.Bucket, fromDest)
+	r.NoError(err, "increment bucket tags from version for second replication")
+
+	_, err = s.IncrementBucketACL(ctx, replID2, obj.Bucket, fromDest)
+	r.NoError(err, "increment bucket ACL from version for second replication")
+
+	// check that versions for second replication are set
+	ver, err = s.GetObj(ctx, replID2, obj)
+	r.NoError(err, "get object version for second replication")
+	r.EqualValues(1, ver.From, "object from version is 1 for second replication")
+	r.EqualValues(0, ver.To, "object to version is 0 for second replication")
+
+	ver, err = s.GetTags(ctx, replID2, obj)
+	r.NoError(err, "get object tags version for second replication")
+	r.EqualValues(1, ver.From, "object tags from version is 1 for second replication")
+	r.EqualValues(0, ver.To, "object tags to version is 0 for second replication")
+
+	ver, err = s.GetACL(ctx, replID2, obj)
+	r.NoError(err, "get object ACL version for second replication")
+	r.EqualValues(1, ver.From, "object ACL from version is 1 for second replication")
+	r.EqualValues(0, ver.To, "object ACL to version is 0 for second replication")
+
+	ver, err = s.GetBucket(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket version for second replication")
+	r.EqualValues(1, ver.From, "bucket from version is 1 for second replication")
+	r.EqualValues(0, ver.To, "bucket to version is 0 for second replication")
+
+	ver, err = s.GetBucketTags(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket tags version for second replication")
+	r.EqualValues(1, ver.From, "bucket tags from version is 1 for second replication")
+	r.EqualValues(0, ver.To, "bucket tags to version is 0 for second replication")
+
+	ver, err = s.GetBucketACL(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket ACL version for second replication")
+	r.EqualValues(1, ver.From, "bucket ACL from version is 1 for second replication")
+	r.EqualValues(0, ver.To, "bucket ACL to version is 0 for second replication")
+
+	// cleanup first replication
+
+	err = s.Cleanup(ctx, replID)
+	r.NoError(err, "cleanup replication versions")
+
+	// check that all versions for the first replication are zero now
+	ver, err = s.GetObj(ctx, replID, obj)
+	r.NoError(err, "get object version after replication cleanup")
+	r.Equal(Version{}, ver, "object version is zero after replication cleanup")
+
+	ver, err = s.GetTags(ctx, replID, obj)
+	r.NoError(err, "get object tags version after replication cleanup")
+	r.Equal(Version{}, ver, "object tags version is zero after replication cleanup")
+
+	ver, err = s.GetACL(ctx, replID, obj)
+	r.NoError(err, "get object ACL version after replication cleanup")
+	r.Equal(Version{}, ver, "object ACL version is zero after replication cleanup")
+
+	ver, err = s.GetBucket(ctx, replID, obj.Bucket)
+	r.NoError(err, "get bucket version after replication cleanup")
+	r.Equal(Version{}, ver, "bucket version is zero after replication cleanup")
+
+	// check that all versions for the second replication remain unaffected
+	ver, err = s.GetObj(ctx, replID2, obj)
+	r.NoError(err, "get object version for second replication after first replication cleanup")
+	r.EqualValues(1, ver.From, "object from version remains for second replication after first replication cleanup")
+	r.EqualValues(0, ver.To, "object to version remains for second replication after first replication cleanup")
+
+	ver, err = s.GetTags(ctx, replID2, obj)
+	r.NoError(err, "get object tags version for second replication after first replication cleanup")
+	r.EqualValues(1, ver.From, "object tags from version remains for second replication after first replication cleanup")
+	r.EqualValues(0, ver.To, "object tags to version remains for second replication after first replication cleanup")
+
+	ver, err = s.GetACL(ctx, replID2, obj)
+	r.NoError(err, "get object ACL version for second replication after first replication cleanup")
+	r.EqualValues(1, ver.From, "object ACL from version remains for second replication after first replication cleanup")
+	r.EqualValues(0, ver.To, "object ACL to version remains for second replication after first replication cleanup")
+
+	ver, err = s.GetBucket(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket version for second replication after first replication cleanup")
+	r.EqualValues(1, ver.From, "bucket from version remains for second replication after first replication cleanup")
+	r.EqualValues(0, ver.To, "bucket to version remains for second replication after first replication cleanup")
+
+	ver, err = s.GetBucketTags(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket tags version for second replication after first replication cleanup")
+	r.EqualValues(1, ver.From, "bucket tags from version remains for second replication after first replication cleanup")
+	r.EqualValues(0, ver.To, "bucket tags to version remains for second replication after first replication cleanup")
+
+	ver, err = s.GetBucketACL(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket ACL version for second replication after first replication cleanup")
+	r.EqualValues(1, ver.From, "bucket ACL from version remains for second replication after first replication cleanup")
+	r.EqualValues(0, ver.To, "bucket ACL to version remains for second replication after first replication cleanup")
+
+	// final cleanup
+	err = s.Cleanup(ctx, replID2)
+	r.NoError(err, "final cleanup of second replication")
+
+	// check that all versions for the second replication are zero now
+	ver, err = s.GetObj(ctx, replID2, obj)
+	r.NoError(err, "get object version after final replication cleanup")
+	r.Equal(Version{}, ver, "object version is zero after final replication cleanup")
+
+	ver, err = s.GetTags(ctx, replID2, obj)
+	r.NoError(err, "get object tags version after final replication cleanup")
+	r.Equal(Version{}, ver, "object tags version is zero after final replication cleanup")
+
+	ver, err = s.GetACL(ctx, replID2, obj)
+	r.NoError(err, "get object ACL version after final replication cleanup")
+	r.Equal(Version{}, ver, "object ACL version is zero after final replication cleanup")
+
+	ver, err = s.GetBucket(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket version after final replication cleanup")
+	r.Equal(Version{}, ver, "bucket version is zero after final replication cleanup")
+
+	ver, err = s.GetBucketTags(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket tags version after final replication cleanup")
+	r.Equal(Version{}, ver, "bucket tags version is zero after final replication cleanup")
+
+	ver, err = s.GetBucketACL(ctx, replID2, obj.Bucket)
+	r.NoError(err, "get bucket ACL version after final replication cleanup")
+	r.Equal(Version{}, ver, "bucket ACL version is zero after final replication cleanup")
+
 }

--- a/pkg/policy/detect_changes.go
+++ b/pkg/policy/detect_changes.go
@@ -25,10 +25,16 @@ import (
 )
 
 const (
-	minSchemaVersion     = 2
-	currentSchemaVersion = 2
+	minSchemaVersion     = 3
+	currentSchemaVersion = 3
 	schemaVersionKey     = "chorus_schema"
 )
+
+var supportedSchemaVersions = map[int]string{
+	0: "v0.5.15 or older",
+	1: "v0.5.15 or older",
+	2: "v0.6.0",
+}
 
 func CheckSchemaCompatibility(ctx context.Context, chorusVersion string, client redis.UniversalClient) error {
 	// Check current schema version in Redis
@@ -49,7 +55,8 @@ func CheckSchemaCompatibility(ctx context.Context, chorusVersion string, client 
 	onlySchemaVersionKey := len(keys) == 1 && keys[0] == schemaVersionKey
 
 	if !onlySchemaVersionKey && len(keys) > 0 {
-		return fmt.Errorf("%w: Chorus version %s is incompatible with existing Redis schema from previous Chorus installations. Please remove all data in Redis to continue with the current version, or use Chorus v0.5.15 or older", dom.ErrInternal, chorusVersion)
+		supportedVersion := supportedSchemaVersions[version]
+		return fmt.Errorf("%w: Chorus version %s is incompatible with existing Redis schema from previous Chorus installations. Please remove all data in Redis to continue with the current version, or use Chorus %s", dom.ErrInternal, chorusVersion, supportedVersion)
 	}
 	// No legacy keys found, consider schema compatible
 	// Set the current schema version to not check again next time

--- a/pkg/policy/detect_changes_test.go
+++ b/pkg/policy/detect_changes_test.go
@@ -51,4 +51,22 @@ func TestCheckSchemaCompatibility(t *testing.T) {
 		r.Error(err)
 		r.ErrorIs(err, dom.ErrInternal)
 	})
+
+	t.Run("has schema verstion 2", func(t *testing.T) {
+		c.FlushAll(ctx)
+		// add at least one key
+		err := c.ZAdd(ctx, "p:repl:from", redis.Z{
+			Score:  5,
+			Member: "to:buck",
+		}).Err()
+		r.NoError(err)
+
+		err = c.Set(ctx, schemaVersionKey, 2, 0).Err()
+		r.NoError(err)
+
+		err = CheckSchemaCompatibility(ctx, "", c)
+		r.Error(err)
+		r.ErrorIs(err, dom.ErrInternal)
+		r.Contains(err.Error(), "v0.6.0")
+	})
 }

--- a/service/worker/server.go
+++ b/service/worker/server.go
@@ -294,7 +294,7 @@ func Start(ctx context.Context, app dom.AppInfo, conf *Config) error {
 	if conf.Api.Enabled {
 		chorusHandler := api.ChorusHandlers(clientRegistry.Config(), rpc.NewProxyClient(appRedis), rpc.NewAgentClient(appRedis), &app)
 		diffHandler := api.DiffHandlers(clientRegistry.Config(), queueSvc, checkSvc)
-		policyHandler := api.PolicyHandlers(clientRegistry, queueSvc, rc, policySvc, versionSvc, objectListStateStore, rpc.NewAgentClient(appRedis), notifications.NewService(clientRegistry), replicationStatusLocker, userLocker)
+		policyHandler := api.PolicyHandlers(clientRegistry, queueSvc, rc, policySvc, versionSvc, objectListStateStore, bucketListStateStore, rpc.NewAgentClient(appRedis), notifications.NewService(clientRegistry), replicationStatusLocker, userLocker)
 		registerServices := func(srv *grpc.Server) {
 			pb.RegisterChorusServer(srv, chorusHandler)
 			pb.RegisterDiffServer(srv, diffHandler)

--- a/test/migration/restart_repl_test.go
+++ b/test/migration/restart_repl_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/clyso/chorus/test/app"
 )
 
-func Test_Restart_Replication(t *testing.T) {
+func Test_Restart_Bucket_Replication(t *testing.T) {
 	e := app.SetupEmbedded(t, workerConf, proxyConf)
 	tstCtx := t.Context()
 
@@ -147,4 +147,161 @@ func Test_Restart_Replication(t *testing.T) {
 	r.Len(diff.Match, 3)
 	r.Empty(diff.MissFrom)
 	r.Empty(diff.MissTo)
+}
+
+func Test_Restart_User_Replication(t *testing.T) {
+	e := app.SetupEmbedded(t, workerConf, proxyConf)
+	tstCtx := t.Context()
+
+	buckets := []string{"restart1", "restart2"}
+	r := require.New(t)
+	for _, bucket := range buckets {
+		err := e.MainClient.MakeBucket(tstCtx, bucket, mclient.MakeBucketOptions{Region: "us-east"})
+		r.NoError(err)
+		ok, err := e.MainClient.BucketExists(tstCtx, bucket)
+		r.NoError(err)
+		r.True(ok)
+		ok, err = e.F1Client.BucketExists(tstCtx, bucket)
+		r.NoError(err)
+		r.False(ok)
+		ok, err = e.F2Client.BucketExists(tstCtx, bucket)
+		r.NoError(err)
+		r.False(ok)
+
+		// add initial objects
+		obj1 := getTestObj("obj1", bucket)
+		_, err = e.MainClient.PutObject(tstCtx, obj1.bucket, obj1.name, bytes.NewReader(obj1.data), int64(len(obj1.data)), mclient.PutObjectOptions{ContentType: "binary/octet-stream"})
+		r.NoError(err)
+		obj2 := getTestObj("obj2", bucket)
+		_, err = e.MainClient.PutObject(tstCtx, obj2.bucket, obj2.name, bytes.NewReader(obj2.data), int64(len(obj2.data)), mclient.PutObjectOptions{ContentType: "binary/octet-stream"})
+		r.NoError(err)
+	}
+	// start replication
+	id := &pb.ReplicationID{
+		User:        user,
+		FromStorage: "main",
+		ToStorage:   "f1",
+		FromBucket:  nil,
+		ToBucket:    nil,
+	}
+	_, err := e.PolicyClient.AddReplication(tstCtx, &pb.AddReplicationRequest{
+		Id: id,
+	})
+	r.NoError(err)
+
+	reps, err := e.PolicyClient.ListReplications(tstCtx, &pb.ListReplicationsRequest{})
+	r.NoError(err)
+	r.Len(reps.Replications, 1)
+	r.True(proto.Equal(id, reps.Replications[0].Id))
+
+	r.Eventually(func() bool {
+		reps, err = e.PolicyClient.ListReplications(tstCtx, &pb.ListReplicationsRequest{})
+		if err != nil {
+			return false
+		}
+		if len(reps.Replications) != 1 {
+			return false
+		}
+		return reps.Replications[0].InitObjDone > 0
+	}, e.WaitShort, e.RetryShort)
+
+	// add live event
+	for _, bucket := range buckets {
+		obj3 := getTestObj("obj3", bucket)
+		_, err = e.ProxyClient.PutObject(tstCtx, obj3.bucket, obj3.name, bytes.NewReader(obj3.data), int64(len(obj3.data)), mclient.PutObjectOptions{ContentType: "binary/octet-stream"})
+		r.NoError(err)
+	}
+
+	// wait replication to be done
+	r.Eventually(func() bool {
+		reps, err = e.PolicyClient.ListReplications(tstCtx, &pb.ListReplicationsRequest{})
+		if err != nil {
+			return false
+		}
+		if len(reps.Replications) != 1 {
+			return false
+		}
+		return reps.Replications[0].IsInitDone && reps.Replications[0].Events > 0 && reps.Replications[0].Events == reps.Replications[0].EventsDone
+	}, e.WaitShort, e.RetryShort)
+
+	for _, bucket := range buckets {
+		buckID := proto.Clone(id).(*pb.ReplicationID)
+		buckID.FromBucket = &bucket
+		buckID.ToBucket = &bucket
+		diff, err := e.PolicyClient.CompareBucket(tstCtx, &pb.CompareBucketRequest{
+			Target:    buckID,
+			ShowMatch: true,
+		})
+		r.NoError(err)
+		r.True(diff.IsMatch)
+		r.Empty(diff.Error)
+		r.Len(diff.Match, 3)
+		r.Empty(diff.MissFrom)
+		r.Empty(diff.MissTo)
+	}
+
+	// delete replication
+	_, err = e.PolicyClient.DeleteReplication(tstCtx, id)
+	r.NoError(err)
+
+	// delete dest bucket
+	for _, bucket := range buckets {
+		r.NoError(rmBucket(e.F1Client, bucket))
+	}
+
+	for _, bucket := range buckets {
+		buckID := proto.Clone(id).(*pb.ReplicationID)
+		buckID.FromBucket = &bucket
+		buckID.ToBucket = &bucket
+		diff, err := e.PolicyClient.CompareBucket(tstCtx, &pb.CompareBucketRequest{
+			Target:    buckID,
+			ShowMatch: true,
+		})
+		r.NoError(err)
+		r.False(diff.IsMatch)
+	}
+
+	reps, err = e.PolicyClient.ListReplications(tstCtx, &pb.ListReplicationsRequest{})
+	r.NoError(err)
+	r.Empty(reps.Replications)
+
+	// restart replication
+	_, err = e.PolicyClient.AddReplication(tstCtx, &pb.AddReplicationRequest{
+		Id: id,
+	})
+	r.NoError(err)
+
+	reps, err = e.PolicyClient.ListReplications(tstCtx, &pb.ListReplicationsRequest{})
+	r.NoError(err)
+	r.Len(reps.Replications, 1)
+
+	// wait replication to be done
+	r.Eventually(func() bool {
+		reps, err = e.PolicyClient.ListReplications(tstCtx, &pb.ListReplicationsRequest{})
+		if err != nil {
+			return false
+		}
+		if len(reps.Replications) != 1 {
+			return false
+		}
+		stat := reps.Replications[0]
+		return stat.IsInitDone && stat.Events == stat.EventsDone
+	}, e.WaitShort, e.RetryShort)
+
+	// check that sync was correct
+	for _, bucket := range buckets {
+		buckID := proto.Clone(id).(*pb.ReplicationID)
+		buckID.FromBucket = &bucket
+		buckID.ToBucket = &bucket
+		diff, err := e.PolicyClient.CompareBucket(tstCtx, &pb.CompareBucketRequest{
+			Target:    buckID,
+			ShowMatch: true,
+		})
+		r.NoError(err)
+		r.True(diff.IsMatch)
+		r.Empty(diff.Error)
+		r.Len(diff.Match, 3)
+		r.Empty(diff.MissFrom)
+		r.Empty(diff.MissTo)
+	}
 }


### PR DESCRIPTION
## Pull Request

- change meta.Version serveice interface to accept replicationID
- added cleanup funcs to lastListedObject/bucket
- call version/lastListed metadata cleanup on delete replication
- added breaking change to schema change detector
