### PR TITLE
fix: prevent duplicate Prometheus metrics registration panic in proxy

### DIFF
--- a/pkg/metrics/http_middleware.go
+++ b/pkg/metrics/http_middleware.go
@@ -40,60 +40,60 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+var proxyTotalRequests = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "proxy_requests_total",
+		Help: "Number of requests to chorus s3 proxy.",
+	},
+	[]string{"method"},
+)
+
+var proxyResponseStatus = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "proxy_response_status",
+		Help: "Status of chorus s3 proxy response.",
+	},
+	[]string{"status"},
+)
+
+var proxyHttpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "proxy_response_time_seconds",
+	Help:    "Duration of chorus s3 proxy requests.",
+	Buckets: prometheus.DefBuckets,
+}, []string{"method"})
+
 func ProxyMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		var totalRequests = promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "proxy_requests_total",
-				Help: "Number of requests to chorus s3 proxy.",
-			},
-			[]string{"method"},
-		)
-
-		var responseStatus = promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "proxy_response_status",
-				Help: "Status of chorus s3 proxy response.",
-			},
-			[]string{"status"},
-		)
-
-		var httpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "proxy_response_time_seconds",
-			Help:    "Duration of chorus s3 proxy requests.",
-			Buckets: prometheus.DefBuckets,
-		}, []string{"method"})
-
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			method := xctx.GetMethod(r.Context())
 
-			timer := prometheus.NewTimer(httpDuration.WithLabelValues(method.String()))
+			timer := prometheus.NewTimer(proxyHttpDuration.WithLabelValues(method.String()))
 			rw := NewResponseWriter(w)
 			next.ServeHTTP(rw, r)
 			statusCode := rw.statusCode
 
-			responseStatus.WithLabelValues(strconv.Itoa(statusCode)).Inc()
-			totalRequests.WithLabelValues(method.String()).Inc()
+			proxyResponseStatus.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+			proxyTotalRequests.WithLabelValues(method.String()).Inc()
 			timer.ObserveDuration()
 		})
 	}
 }
 
-func AgentMiddleware(next http.Handler) http.Handler {
-	var totalRequests = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "agent_requests_total",
-			Help: "Number of requests to chorus agent.",
-		},
-		[]string{"status"},
-	)
+var agentTotalRequests = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "agent_requests_total",
+		Help: "Number of requests to chorus agent.",
+	},
+	[]string{"status"},
+)
 
+func AgentMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		rw := NewResponseWriter(w)
 		next.ServeHTTP(rw, r)
 		statusCode := rw.statusCode
 
-		totalRequests.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+		agentTotalRequests.WithLabelValues(strconv.Itoa(statusCode)).Inc()
 	})
 }

--- a/pkg/metrics/worker_middleware.go
+++ b/pkg/metrics/worker_middleware.go
@@ -24,53 +24,50 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// Metrics variables.
+var workerProcessedCounter = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "worker_processed_tasks_total",
+		Help: "The total number of processed tasks",
+	},
+	[]string{"queue", "task_type"},
+)
+
+var workerFailedCounter = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "worker_failed_tasks_total",
+		Help: "The total number of times processing failed",
+	},
+	[]string{"queue", "task_type"},
+)
+
+var workerInProgressGauge = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "worker_in_progress_tasks",
+		Help: "The number of tasks currently being processed",
+	},
+	[]string{"queue", "task_type"},
+)
+
+var workerTaskDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "worker_task_duration_seconds",
+	Help:    "Task processing time in seconds.",
+	Buckets: prometheus.ExponentialBucketsRange(0.1, 600, 11),
+}, []string{"queue", "task_type"})
 
 func WorkerMiddleware() asynq.MiddlewareFunc {
-	var (
-		processedCounter = promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "worker_processed_tasks_total",
-				Help: "The total number of processed tasks",
-			},
-			[]string{"queue", "task_type"},
-		)
-
-		failedCounter = promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "worker_failed_tasks_total",
-				Help: "The total number of times processing failed",
-			},
-			[]string{"queue", "task_type"},
-		)
-
-		inProgressGauge = promauto.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "worker_in_progress_tasks",
-				Help: "The number of tasks currently being processed",
-			},
-			[]string{"queue", "task_type"},
-		)
-
-		taskDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "worker_task_duration_seconds",
-			Help:    "Task processing time in seconds.",
-			Buckets: prometheus.ExponentialBucketsRange(0.1, 600, 11),
-		}, []string{"queue", "task_type"})
-	)
 	return func(next asynq.Handler) asynq.Handler {
 		return asynq.HandlerFunc(func(ctx context.Context, t *asynq.Task) error {
 			queue, _ := asynq.GetQueueName(ctx)
-			timer := prometheus.NewTimer(taskDuration.WithLabelValues(queue, t.Type()))
+			timer := prometheus.NewTimer(workerTaskDuration.WithLabelValues(queue, t.Type()))
 
-			inProgressGauge.WithLabelValues(queue, t.Type()).Inc()
+			workerInProgressGauge.WithLabelValues(queue, t.Type()).Inc()
 			err := next.ProcessTask(ctx, t)
 			timer.ObserveDuration()
-			inProgressGauge.WithLabelValues(queue, t.Type()).Dec()
+			workerInProgressGauge.WithLabelValues(queue, t.Type()).Dec()
 			if err != nil {
-				failedCounter.WithLabelValues(queue, t.Type()).Inc()
+				workerFailedCounter.WithLabelValues(queue, t.Type()).Inc()
 			}
-			processedCounter.WithLabelValues(queue, t.Type()).Inc()
+			workerProcessedCounter.WithLabelValues(queue, t.Type()).Inc()
 			return err
 		})
 	}


### PR DESCRIPTION
## Summary
- Fix proxy startup panic when both S3 and Swift storage types are configured
- Move Prometheus metric registration from inner closure to ProxyMiddleware() body so collectors are registered once

Fixes #200

## Root cause
ProxyMiddleware() returns a closure that calls promauto.NewCounterVec/NewHistogramVec each time it wraps a handler. router.New() applies this middleware once per storage type — when both S3 and Swift are configured, the second invocation re-registers the same metric names, causing a panic.

## Changes
- pkg/metrics/http_middleware.go: Move 3 metric variable declarations (proxy_requests_total, proxy_response_status, proxy_response_time_seconds) outside the returned closure

## Test plan
- [ ] go build ./cmd/proxy/ compiles cleanly
- [ ] go vet ./pkg/metrics/... passes
- [ ] Deploy with both S3 and Swift storages configured — proxy starts without panic