### PR TITLE
marshal default values on grpc gateway to not ignore enums

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
       - name: make test
         run: make test TEST_WAIT_SHORT=20s TEST_WAIT_LONG=80s
       - name: Run Proto Generation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
       - name: Install zip
         uses: montudor/action-zip@v1
       - name: Build standalone binaries

--- a/.govulncheck-ignore.yaml
+++ b/.govulncheck-ignore.yaml
@@ -1,0 +1,21 @@
+# Allowlist for `make vuln` (consumed by scripts/vuln-check.sh).
+#
+# Schema: bare YAML list. Each entry is required to have all three fields
+# below; key order within an entry is free.
+#
+#   id:     The Go vulnerability ID (GO-YYYY-NNNN).
+#   module: The exact module path the advisory targets. The scanner's
+#           "Found in:" must match this value — pinning the ID to a specific
+#           module prevents the entry from silently masking the same advisory
+#           if it ever surfaces against a different dependency.
+#   reason: Why we accept the vuln. Should usually start with
+#           "No fix available". When upstream ships a fix, the scanner stops
+#           reporting the ID and the wrapper flags this entry as stale,
+#           failing `make vuln` until it is removed.
+
+- id: GO-2026-4887
+  module: github.com/docker/docker
+  reason: "No fix available — Moby AuthZ plugin bypass on oversized request bodies. Pulled in only via testcontainers-go from test/env/components.go (test infra); not linked into product binaries."
+- id: GO-2026-4883
+  module: github.com/docker/docker
+  reason: "No fix available — Moby off-by-one error in plugin privilege validation. Pulled in only via testcontainers-go from test/env/components.go (test infra); not linked into product binaries."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 ARG GIT_COMMIT='not set'
 ARG GIT_TAG=development
 ENV GIT_COMMIT=$GIT_COMMIT

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint:
 
 .PHONY: vuln
 vuln:
-	go tool govulncheck ./...
+	./scripts/vuln-check.sh
 
 .PHONY: license-check
 license-check:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clyso/chorus
 
-go 1.26.1
+go 1.26.2
 
 replace (
 	github.com/hibiken/asynq => github.com/clyso/asynq v0.0.0-20251202163730-20cb0d89aa76

--- a/pkg/api/grpc_http_gateway.go
+++ b/pkg/api/grpc_http_gateway.go
@@ -37,6 +37,7 @@ type RegisterHandlersFunc func(ctx context.Context, mux *runtime.ServeMux, endpo
 func GRPCGateway(ctx context.Context, conf *Config, register RegisterHandlersFunc) (start func(context.Context) error, stop func(context.Context) error, err error) {
 	mux := runtime.NewServeMux(
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
+			MarshalOptions:   protojson.MarshalOptions{EmitUnpopulated: true},
 			UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: true},
 		}),
 	)

--- a/scripts/vuln-check.sh
+++ b/scripts/vuln-check.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Wrap `go tool govulncheck` and apply .govulncheck-ignore.yaml.
+# See that file for the allowlist schema.
+#
+# Exit codes:
+#   0 — clean scan, or every reported vuln has a matching (id+module)
+#       allowlist entry.
+#   1 — allowlist contains stale entries, or YAML failed schema validation.
+#       (Distinct from govulncheck's own non-zero — these are maintenance
+#       issues, not vulnerability findings.)
+#   non-zero (govulncheck's) — a vuln was reported that the allowlist does
+#       not cover.
+
+set -uo pipefail
+
+IGNORE_FILE="${IGNORE_FILE:-.govulncheck-ignore.yaml}"
+
+scan_out=$(mktemp)
+found_pairs=$(mktemp)
+allowed_pairs=$(mktemp)
+trap 'rm -f "$scan_out" "$found_pairs" "$allowed_pairs"' EXIT
+
+go tool govulncheck ./... >"$scan_out" 2>&1
+code=$?
+cat "$scan_out"
+
+if [ "$code" -eq 0 ]; then
+    exit 0
+fi
+
+# govulncheck format is fixed: each "Vulnerability #N: GO-..." block is
+# followed by a "Found in: <module>@<ver>" line — id is always $3 on the
+# header, module path is always $3 (pre-@) on the Found-in line.
+awk '
+    /^Vulnerability #[0-9]+:/ { id = $3 }
+    /^[[:space:]]+Found in:/ {
+        m = $3; sub(/@.*/, "", m)
+        if (id != "") print id "\t" m
+    }
+' "$scan_out" | sort -u >"$found_pairs"
+
+# Parse the YAML allowlist into id<TAB>module pairs. The parser:
+#   - accepts free key order within an entry (id/module/reason in any sequence)
+#   - validates that every entry has a non-empty id, module, and reason
+#   - errors clearly on missing/empty fields rather than silently miscounting
+if [ -f "$IGNORE_FILE" ]; then
+    awk '
+        function unquote(v) {
+            sub(/^"/, "", v); sub(/"$/, "", v)
+            sub(/^'\''/, "", v); sub(/'\''$/, "", v)
+            return v
+        }
+        function flush() {
+            if (id == "") {
+                printf "error: entry near line %d missing or empty `id`\n", entry_line > "/dev/stderr"
+                bad = 1
+            } else if (module == "") {
+                printf "error: entry %s missing or empty `module`\n", id > "/dev/stderr"
+                bad = 1
+            } else if (reason == "") {
+                printf "error: entry %s missing or empty `reason`\n", id > "/dev/stderr"
+                bad = 1
+            } else {
+                print id "\t" module
+            }
+            id = ""; module = ""; reason = ""
+        }
+        /^[[:space:]]*-/ {
+            if (have) flush()
+            have = 1
+            entry_line = NR
+        }
+        {
+            s = $0
+            sub(/^[[:space:]]*-?[[:space:]]*/, "", s)
+            if (match(s, /^id:[[:space:]]*/)) {
+                v = substr(s, RSTART + RLENGTH)
+                sub(/[[:space:]]+#.*$/, "", v); sub(/[[:space:]\r]+$/, "", v)
+                id = unquote(v)
+            } else if (match(s, /^module:[[:space:]]*/)) {
+                v = substr(s, RSTART + RLENGTH)
+                sub(/[[:space:]]+#.*$/, "", v); sub(/[[:space:]\r]+$/, "", v)
+                module = unquote(v)
+            } else if (match(s, /^reason:[[:space:]]*/)) {
+                v = substr(s, RSTART + RLENGTH)
+                sub(/[[:space:]\r]+$/, "", v)
+                reason = unquote(v)
+            }
+        }
+        END { if (have) flush(); if (bad) exit 1 }
+    ' "$IGNORE_FILE" | sort -u >"$allowed_pairs" || {
+        printf '\n>>> Failed to parse %s — fix the schema errors above.\n' "$IGNORE_FILE" >&2
+        exit 1
+    }
+fi
+
+unexpected=$(comm -23 "$found_pairs" "$allowed_pairs")
+if [ -n "$unexpected" ]; then
+    printf '\n>>> Unexpected vulnerabilities (id\tmodule) not allowlisted in %s:\n%s\n' \
+        "$IGNORE_FILE" "$unexpected" >&2
+    # If an ID is allowlisted but for a different module, surface the
+    # mismatch — the exact failure mode the strict id+module pairing catches.
+    awk -F'\t' '
+        NR==FNR { allowed_module[$1] = $2; next }
+        ($1 in allowed_module) && allowed_module[$1] != $2 {
+            printf "    note: %s is allowlisted for module %s but the scanner reports module %s\n",
+                $1, allowed_module[$1], $2
+        }
+    ' "$allowed_pairs" - <<<"$unexpected" >&2
+    exit "$code"
+fi
+
+stale=$(comm -13 "$found_pairs" "$allowed_pairs")
+if [ -n "$stale" ]; then
+    # Stale entries mean the scan succeeded but the allowlist has rotted —
+    # exit 1 is intentional here, distinct from govulncheck's failure code.
+    printf '\n>>> Stale entries in %s (no longer reported by the scanner — please remove):\n%s\n' \
+        "$IGNORE_FILE" "$stale" >&2
+    exit 1
+fi
+
+printf '\n>>> All reported vulnerabilities are allowlisted in %s — PASS\n' "$IGNORE_FILE"

--- a/test/migration/api_test.go
+++ b/test/migration/api_test.go
@@ -1,8 +1,9 @@
 package migration
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
-	"net/http/httputil"
 	"testing"
 
 	mclient "github.com/minio/minio-go/v7"
@@ -20,13 +21,29 @@ func Test_api_storages(t *testing.T) {
 	res, err := e.ChorusClient.GetStorages(tstCtx, &emptypb.Empty{})
 	r.NoError(err)
 	r.Len(res.Storages, 3)
+	r.EqualValues(pb.Storage_S3, res.Storages[0].Provider)
 	resp, err := http.Get(e.UrlHttpApi + "/storage")
 	r.NoError(err)
+	defer resp.Body.Close()
 	r.EqualValues(http.StatusOK, resp.StatusCode)
 	r.Positive(resp.ContentLength)
 
-	_, err = httputil.DumpResponse(resp, true)
+	body, err := io.ReadAll(resp.Body)
 	r.NoError(err)
+	t.Log(string(body))
+
+	var httpRes struct {
+		Storages []struct {
+			Name     string  `json:"name"`
+			Provider *string `json:"provider"`
+		} `json:"storages"`
+	}
+	r.NoError(json.Unmarshal(body, &httpRes))
+	r.Len(httpRes.Storages, 3)
+	for _, s := range httpRes.Storages {
+		r.NotNil(s.Provider, "provider field missing in HTTP JSON for storage %q — protojson omits zero-valued enums unless EmitUnpopulated is set", s.Name)
+		r.EqualValues("S3", *s.Provider)
+	}
 }
 
 func Test_api_proxy_creds(t *testing.T) {

--- a/tools/bench/go.mod
+++ b/tools/bench/go.mod
@@ -1,6 +1,6 @@
 module github.com/clyso/chorus/tools/bench
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/boltdb/bolt v1.3.1

--- a/tools/chorctl/go.mod
+++ b/tools/chorctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/clyso/chorus/tools/chorctl
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbles v0.16.1


### PR DESCRIPTION
## Pull Request

Closes #204 

also contains:
- go version upgrade to fix govulncheck
- govulncheck wrapper to support ingnore list. testcontainres docker dependecy has unfixed vuln preventing from merge. used only in test. alternatively, can ignore test packages in vluncheck.
