### PR TITLE
feat(ui): Add storage credentials list

### DIFF
--- a/ui/src/assets/icons/base/create.svg
+++ b/ui/src/assets/icons/base/create.svg
@@ -1,0 +1,17 @@
+<!--
+  - Copyright © 2026 Clyso GmbH
+  -
+  -  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+  -  you may not use this file except in compliance with the License.
+  -  You may obtain a copy of the License at
+  -
+  -  https://www.gnu.org/licenses/agpl-3.0.html
+  -
+  -  Unless required by applicable law or agreed to in writing, software
+  -  distributed under the License is distributed on an "AS IS" BASIS,
+  -  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -  See the License for the specific language governing permissions and
+  -  limitations under the License.
+  -->
+
+<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512"><path d="M384 224v184a40 40 0 01-40 40H104a40 40 0 01-40-40V168a40 40 0 0140-40h167.48" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/><path d="M459.94 53.25a16.06 16.06 0 00-23.22-.56L424.35 65a8 8 0 000 11.31l11.34 11.32a8 8 0 0011.34 0l12.06-12c6.1-6.09 6.67-16.01.85-22.38zM399.34 90L218.82 270.2a9 9 0 00-2.31 3.93L208.16 299a3.91 3.91 0 004.86 4.86l24.85-8.35a9 9 0 003.93-2.31L422 112.66a9 9 0 000-12.66l-9.95-10a9 9 0 00-12.71 0z"/></svg>

--- a/ui/src/components/chorus/credentials/CredentialsActionsCell/CredentialsActionsCell.vue
+++ b/ui/src/components/chorus/credentials/CredentialsActionsCell/CredentialsActionsCell.vue
@@ -16,16 +16,18 @@
 
 <script setup lang="ts">
   import { CButton, CTooltip, CIcon } from '@clyso/clyso-ui-kit';
-  import { storeToRefs } from 'pinia';
   import { useI18n } from 'vue-i18n';
   import i18nCredentials from '../i18nCredentials';
-  import { useChorusStorageDetailsStore } from '@/stores/chorusStorageDetailsStore';
+  import { IconName } from '@/utils/types/icon';
+  import type { ChorusCredential } from '@/utils/types/chorus';
 
   const { t } = useI18n({
     messages: i18nCredentials,
   });
 
-  const { storage } = storeToRefs(useChorusStorageDetailsStore());
+  defineProps<{
+    credential: ChorusCredential;
+  }>();
 </script>
 
 <template>
@@ -43,12 +45,11 @@
                 secondary
                 size="tiny"
                 type="primary"
-                :loading="!storage"
               >
                 <template #icon>
                   <CIcon
                     :is-inline="true"
-                    name="base-create"
+                    :name="IconName.BASE_CREATE"
                   />
                 </template>
               </CButton>

--- a/ui/src/components/chorus/credentials/CredentialsActionsCell/CredentialsActionsCell.vue
+++ b/ui/src/components/chorus/credentials/CredentialsActionsCell/CredentialsActionsCell.vue
@@ -1,0 +1,62 @@
+<!--
+  - Copyright © 2026 Clyso GmbH
+  -
+  -  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+  -  you may not use this file except in compliance with the License.
+  -  You may obtain a copy of the License at
+  -
+  -  https://www.gnu.org/licenses/agpl-3.0.html
+  -
+  -  Unless required by applicable law or agreed to in writing, software
+  -  distributed under the License is distributed on an "AS IS" BASIS,
+  -  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -  See the License for the specific language governing permissions and
+  -  limitations under the License.
+  -->
+
+<script setup lang="ts">
+  import { CButton, CTooltip, CIcon } from '@clyso/clyso-ui-kit';
+  import { storeToRefs } from 'pinia';
+  import { useI18n } from 'vue-i18n';
+  import i18nCredentials from '../i18nCredentials';
+  import { useChorusStorageDetailsStore } from '@/stores/chorusStorageDetailsStore';
+
+  const { t } = useI18n({
+    messages: i18nCredentials,
+  });
+
+  const { storage } = storeToRefs(useChorusStorageDetailsStore());
+</script>
+
+<template>
+  <div class="credentials-actions-cell">
+    <div class="actions-list">
+      <div class="actions-list__item actions-list__item--edit">
+        <CTooltip :delay="1000">
+          <template #trigger>
+            <RouterLink
+              :to="{
+                // name & params: TODO: add route name, once defined
+              }"
+            >
+              <CButton
+                secondary
+                size="tiny"
+                type="primary"
+                :loading="!storage"
+              >
+                <template #icon>
+                  <CIcon
+                    :is-inline="true"
+                    name="base-create"
+                  />
+                </template>
+              </CButton>
+            </RouterLink>
+          </template>
+          {{ t('actionEdit') }}
+        </CTooltip>
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/chorus/credentials/CredentialsFilterByUserAlias/CredentialsFilterByUserAlias.vue
+++ b/ui/src/components/chorus/credentials/CredentialsFilterByUserAlias/CredentialsFilterByUserAlias.vue
@@ -1,0 +1,44 @@
+<!--
+  - Copyright © 2026 Clyso GmbH
+  -
+  -  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+  -  you may not use this file except in compliance with the License.
+  -  You may obtain a copy of the License at
+  -
+  -  https://www.gnu.org/licenses/agpl-3.0.html
+  -
+  -  Unless required by applicable law or agreed to in writing, software
+  -  distributed under the License is distributed on an "AS IS" BASIS,
+  -  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -  See the License for the specific language governing permissions and
+  -  limitations under the License.
+  -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { useI18n } from 'vue-i18n';
+  import { computed } from 'vue';
+  import i18nCredentials from '../i18nCredentials';
+  import ChorusUserFilter from '../../common/ChorusUserFilter/ChorusUserFilter.vue';
+  import { useChorusStorageDetailsStore } from '@/stores/chorusStorageDetailsStore';
+
+  const { t } = useI18n({
+    messages: i18nCredentials,
+  });
+
+  const { credentialsList, credentialsFilterAlias, credentialsPage } =
+    storeToRefs(useChorusStorageDetailsStore());
+
+  const credentials = computed(() =>
+    credentialsList.value.map((credential) => credential.alias),
+  );
+</script>
+
+<template>
+  <ChorusUserFilter
+    v-model:filterValue="credentialsFilterAlias"
+    :users="credentials"
+    :placeholder="t('filterByUserAliasPlaceholder')"
+    @update:filter-value="credentialsPage = 1"
+  />
+</template>

--- a/ui/src/components/chorus/credentials/CredentialsFilterByUserAlias/CredentialsFilterByUserAlias.vue
+++ b/ui/src/components/chorus/credentials/CredentialsFilterByUserAlias/CredentialsFilterByUserAlias.vue
@@ -26,7 +26,7 @@
     messages: i18nCredentials,
   });
 
-  const { credentialsList, credentialsFilterAlias, credentialsPage } =
+  const { credentialsList, credentialsFilterAliases, credentialsPage } =
     storeToRefs(useChorusStorageDetailsStore());
 
   const credentials = computed(() =>
@@ -36,7 +36,7 @@
 
 <template>
   <ChorusUserFilter
-    v-model:filterValue="credentialsFilterAlias"
+    v-model:filterValue="credentialsFilterAliases"
     :users="credentials"
     :placeholder="t('filterByUserAliasPlaceholder')"
     @update:filter-value="credentialsPage = 1"

--- a/ui/src/components/chorus/credentials/CredentialsFilters/CredentialsFilters.vue
+++ b/ui/src/components/chorus/credentials/CredentialsFilters/CredentialsFilters.vue
@@ -1,0 +1,73 @@
+<!--
+  - Copyright © 2026 Clyso GmbH
+  -
+  -  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+  -  you may not use this file except in compliance with the License.
+  -  You may obtain a copy of the License at
+  -
+  -  https://www.gnu.org/licenses/agpl-3.0.html
+  -
+  -  Unless required by applicable law or agreed to in writing, software
+  -  distributed under the License is distributed on an "AS IS" BASIS,
+  -  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -  See the License for the specific language governing permissions and
+  -  limitations under the License.
+  -->
+
+<script setup lang="ts">
+  import { storeToRefs } from 'pinia';
+  import { CSkeleton } from '@clyso/clyso-ui-kit';
+  import CredentialsFilterByUserAlias from '../CredentialsFilterByUserAlias/CredentialsFilterByUserAlias.vue';
+  import { useChorusStorageDetailsStore } from '@/stores/chorusStorageDetailsStore';
+
+  const { isLoading } = storeToRefs(useChorusStorageDetailsStore());
+</script>
+
+<template>
+  <div class="credentials-filters">
+    <div
+      v-if="isLoading"
+      key="loading"
+      class="credentials-filters__list"
+    >
+      <CSkeleton
+        v-for="(_, index) in Array(1)"
+        :key="index"
+        :height="34"
+        :border-radius="4"
+      />
+    </div>
+    <div
+      v-else
+      key="filters"
+      class="credentials-filters__list"
+    >
+      <CredentialsFilterByUserAlias class="credentials-filters__user-alias" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  @use '@/styles/utils' as utils;
+
+  .credentials-filters {
+    padding: 24px 16px;
+    border-radius: 12px;
+    background-color: var(--filters-card-color);
+    border: 1px solid var(--border-color);
+
+    @include utils.mobile {
+      padding: 0;
+      border-radius: 0;
+      background-color: unset;
+      border: 0;
+    }
+
+    &__list {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: utils.unit(5) utils.unit(3);
+      align-items: start;
+    }
+  }
+</style>

--- a/ui/src/components/chorus/credentials/CredentialsFilters/CredentialsFilters.vue
+++ b/ui/src/components/chorus/credentials/CredentialsFilters/CredentialsFilters.vue
@@ -31,8 +31,7 @@
       class="credentials-filters__list"
     >
       <CSkeleton
-        v-for="(_, index) in Array(1)"
-        :key="index"
+        :key="0"
         :height="34"
         :border-radius="4"
       />

--- a/ui/src/components/chorus/credentials/CredentialsList/CredentialsList.vue
+++ b/ui/src/components/chorus/credentials/CredentialsList/CredentialsList.vue
@@ -1,0 +1,134 @@
+<!--
+  - Copyright © 2026 Clyso GmbH
+  -
+  -  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+  -  you may not use this file except in compliance with the License.
+  -  You may obtain a copy of the License at
+  -
+  -  https://www.gnu.org/licenses/agpl-3.0.html
+  -
+  -  Unless required by applicable law or agreed to in writing, software
+  -  distributed under the License is distributed on an "AS IS" BASIS,
+  -  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -  See the License for the specific language governing permissions and
+  -  limitations under the License.
+  -->
+
+<script setup lang="ts">
+  import type {
+    DataTableBaseColumn,
+    DataTableSortState,
+  } from '@clyso/clyso-ui-kit';
+  import { CDataTable } from '@clyso/clyso-ui-kit';
+  import { computed } from 'vue';
+  import { storeToRefs } from 'pinia';
+  import { useI18n } from 'vue-i18n';
+  import i18nCredentials from '../i18nCredentials';
+  import CredentialsActionsCell from '../CredentialsActionsCell/CredentialsActionsCell.vue';
+  import type { ChorusCredential } from '@/utils/types/chorus';
+  import { useChorusStorageDetailsStore } from '@/stores/chorusStorageDetailsStore';
+
+  const { t } = useI18n({
+    messages: i18nCredentials,
+  });
+
+  const {
+    isLoading,
+    hasError,
+    storage,
+    credentialsSorter,
+    credentialsPage,
+    credentialsPageSize,
+    credentialsPagination,
+    computedCredentials,
+  } = storeToRefs(useChorusStorageDetailsStore());
+  const { initStorageDetails } = useChorusStorageDetailsStore();
+
+  const columns = computed<DataTableBaseColumn<ChorusCredential>[]>(() => [
+    {
+      title: t('columnUserAlias'),
+      key: 'alias',
+      sorter: true,
+    },
+    {
+      title: t('columnAccessKey'),
+      key: 'accessKey',
+      sorter: true,
+    },
+    {
+      title: t('columnActions'),
+      key: 'actions',
+    },
+  ]);
+
+  const handleSortingChange = (newSorter: DataTableSortState | null) => {
+    if (!computedCredentials.value.length) {
+      return;
+    }
+
+    credentialsSorter.value = newSorter;
+    credentialsPage.value = 1;
+  };
+
+  const handlePageChange = (newPage: number) => {
+    credentialsPage.value = newPage;
+  };
+
+  const handlePageSizeUpdate = (newPageSize: number) => {
+    credentialsPageSize.value = newPageSize;
+    credentialsPage.value = 1;
+  };
+
+  const rowKey = (row: ChorusCredential) => row.alias;
+</script>
+
+<template>
+  <div class="credentials-list">
+    <div class="credentials-list__container">
+      <CDataTable
+        class="credentials-list__table"
+        :columns="columns"
+        :data="computedCredentials"
+        max-height="1020px"
+        virtual-scroll
+        :is-controlled="true"
+        :is-loading="isLoading"
+        :has-error="hasError"
+        :bordered="false"
+        :sorter="credentialsSorter"
+        :row-key="rowKey"
+        :pagination="credentialsPagination"
+        @update:sorter="handleSortingChange"
+        @update:page="handlePageChange"
+        @update:page-size="handlePageSizeUpdate"
+        @retry="initStorageDetails(storage?.name ?? '')"
+      >
+        <template #alias="{ rowData }">
+          {{ rowData.alias }}
+        </template>
+
+        <template #accessKey="{ rowData }">
+          {{ rowData.accessKey }}
+        </template>
+
+        <template #actions="{ rowData }">
+          <CredentialsActionsCell :credential="rowData as ChorusCredential" />
+        </template>
+      </CDataTable>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  @use '@/styles/utils' as utils;
+
+  .credentials-list {
+    &__container {
+      overflow-x: auto;
+    }
+
+    &__table {
+      min-width: 600px;
+    }
+  }
+</style>

--- a/ui/src/components/chorus/credentials/CredentialsTile/CredentialsTile.vue
+++ b/ui/src/components/chorus/credentials/CredentialsTile/CredentialsTile.vue
@@ -45,9 +45,5 @@
     &__filters {
       margin-bottom: utils.unit(6);
     }
-
-    &__actions {
-      margin-bottom: utils.unit(4);
-    }
   }
 </style>

--- a/ui/src/components/chorus/credentials/CredentialsTile/CredentialsTile.vue
+++ b/ui/src/components/chorus/credentials/CredentialsTile/CredentialsTile.vue
@@ -1,0 +1,53 @@
+<!--
+  - Copyright © 2026 Clyso GmbH
+  -
+  -  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+  -  you may not use this file except in compliance with the License.
+  -  You may obtain a copy of the License at
+  -
+  -  https://www.gnu.org/licenses/agpl-3.0.html
+  -
+  -  Unless required by applicable law or agreed to in writing, software
+  -  distributed under the License is distributed on an "AS IS" BASIS,
+  -  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  -  See the License for the specific language governing permissions and
+  -  limitations under the License.
+  -->
+
+<script setup lang="ts">
+  import { CTile } from '@clyso/clyso-ui-kit';
+  import { useI18n } from 'vue-i18n';
+  import i18nCredentials from '../i18nCredentials';
+  import CredentialsList from '../CredentialsList/CredentialsList.vue';
+  import CredentialsFilters from '../CredentialsFilters/CredentialsFilters.vue';
+
+  const { t } = useI18n({
+    messages: i18nCredentials,
+  });
+</script>
+
+<template>
+  <CTile class="credentials-tile">
+    <template #title>
+      {{ t('credentialsTitle') }}
+    </template>
+
+    <CredentialsFilters class="credentials-tile__filters" />
+
+    <CredentialsList class="credentials-tile__credentials" />
+  </CTile>
+</template>
+
+<style lang="scss" scoped>
+  @use '@/styles/utils' as utils;
+
+  .credentials-tile {
+    &__filters {
+      margin-bottom: utils.unit(6);
+    }
+
+    &__actions {
+      margin-bottom: utils.unit(4);
+    }
+  }
+</style>

--- a/ui/src/components/chorus/credentials/i18nCredentials.ts
+++ b/ui/src/components/chorus/credentials/i18nCredentials.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2026 Clyso GmbH
+ *
+ *  Licensed under the GNU Affero General Public License, Version 3.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { I18nLocale, type I18nMessages } from '@clyso/clyso-ui-kit';
+
+export default <I18nMessages>{
+  [I18nLocale.EN]: {
+    credentialsTitle: 'Credentials',
+    columnUserAlias: 'User Alias',
+    columnAccessKey: 'Access Key',
+    columnActions: 'Actions',
+    filterByUserAliasPlaceholder: 'Filter by User Alias',
+    actionEdit: 'Edit',
+  },
+  [I18nLocale.DE]: {
+    credentialsTitle: 'Zugangsdaten',
+    columnUserAlias: 'Benutzeralias',
+    columnAccessKey: 'Zugriffsschlüssel',
+    columnActions: 'Aktionen',
+    filterByUserAliasPlaceholder: 'Nach Benutzeralias filtern',
+    actionEdit: 'Bearbeiten',
+  },
+};

--- a/ui/src/components/chorus/replications/ReplicationsFilters/ReplicationsFilters.vue
+++ b/ui/src/components/chorus/replications/ReplicationsFilters/ReplicationsFilters.vue
@@ -36,7 +36,7 @@
       class="replications-filters__list"
     >
       <CSkeleton
-        v-for="(_, index) in Array(5)"
+        v-for="(_, index) in Array(6)"
         :key="index"
         :height="34"
         :border-radius="4"
@@ -57,7 +57,7 @@
 
       <ReplicationsFilterByToStorage class="replications-filters__to-storage" />
 
-      <ReplicationsFilterByStatus class="replications-filters__bucket" />
+      <ReplicationsFilterByStatus class="replications-filters__status" />
     </div>
   </div>
 </template>

--- a/ui/src/pages/ChorusStorageDetailsPage/ChorusStorageDetailsPage.vue
+++ b/ui/src/pages/ChorusStorageDetailsPage/ChorusStorageDetailsPage.vue
@@ -30,6 +30,7 @@
   import i18nStorageDetails from '@/components/chorus/storage-details/i18nStorageDetails';
   import StorageGeneral from '@/components/chorus/storage-details/StorageGeneral/StorageGeneral.vue';
   import ChorusStorageProvider from '@/components/chorus/common/ChorusStorageProvider/ChorusStorageProvider.vue';
+  import CredentialsTile from '@/components/chorus/credentials/CredentialsTile/CredentialsTile.vue';
 
   const props = defineProps<{
     storageName: string;
@@ -113,6 +114,7 @@
       class="storage-details-page__content"
     >
       <StorageGeneral class="storage-details-page__general" />
+      <CredentialsTile class="storage-details-page__credentials" />
     </div>
   </CDashboardPage>
 </template>

--- a/ui/src/stores/chorusStorageDetailsStore.ts
+++ b/ui/src/stores/chorusStorageDetailsStore.ts
@@ -33,11 +33,10 @@ interface ChorusStorageDetailsState {
   hasError: boolean;
   storage: ChorusStorage | null;
 
-  credentialsList: ChorusCredential[];
   credentialsSorter: DataTableSortState | null;
   credentialsPage: number;
   credentialsPageSize: number;
-  credentialsFilterAlias: string[];
+  credentialsFilterAliases: string[];
 }
 
 function getInitialState(): ChorusStorageDetailsState {
@@ -46,11 +45,10 @@ function getInitialState(): ChorusStorageDetailsState {
     hasError: false,
     storage: null,
 
-    credentialsList: [],
     credentialsSorter: null,
     credentialsPage: 1,
     credentialsPageSize: CREDENTIALS_PAGE_SIZES[0],
-    credentialsFilterAlias: [],
+    credentialsFilterAliases: [],
   };
 }
 
@@ -72,8 +70,8 @@ export const useChorusStorageDetailsStore = defineStore(
 
         if (state.storage === null) {
           router.push({ name: RouteName.CHORUS_STORAGES });
-        } else {
-          state.credentialsList = state.storage.credentials;
+
+          return;
         }
       } catch {
         state.hasError = true;
@@ -82,17 +80,21 @@ export const useChorusStorageDetailsStore = defineStore(
       }
     }
 
+    const credentialsList = computed<ChorusCredential[]>(
+      () => state.storage?.credentials ?? [],
+    );
+
     const filteredCredentials = computed<ChorusCredential[]>(() =>
-      state.credentialsList.filter((credential) => {
+      credentialsList.value.filter((credential) => {
         return (
-          !state.credentialsFilterAlias.length ||
-          state.credentialsFilterAlias.includes(credential.alias)
+          !state.credentialsFilterAliases.length ||
+          state.credentialsFilterAliases.includes(credential.alias)
         );
       }),
     );
 
     const isCredentialsFiltered = computed<boolean>(
-      () => state.credentialsFilterAlias.length !== 0,
+      () => state.credentialsFilterAliases.length !== 0,
     );
 
     const computedCredentials = computed<ChorusCredential[]>(() => {
@@ -125,7 +127,7 @@ export const useChorusStorageDetailsStore = defineStore(
         }
 
         if (isCredentialsFiltered.value) {
-          return `Filtered: ${filteredCredentials.value.length} / Total: ${state.credentialsList.length}`;
+          return `Filtered: ${filteredCredentials.value.length} / Total: ${credentialsList.value.length}`;
         }
 
         return `Total: ${itemCount}`;
@@ -138,6 +140,7 @@ export const useChorusStorageDetailsStore = defineStore(
 
     return {
       ...toRefs(state),
+      credentialsList,
       initStorageDetails,
       computedCredentials,
       credentialsPagination,

--- a/ui/src/stores/chorusStorageDetailsStore.ts
+++ b/ui/src/stores/chorusStorageDetailsStore.ts
@@ -15,16 +15,29 @@
  */
 
 import { defineStore } from 'pinia';
-import { reactive, toRefs } from 'vue';
+import { computed, reactive, toRefs } from 'vue';
 import { useRouter } from 'vue-router';
-import type { ChorusStorage } from '@/utils/types/chorus';
+import type {
+  DataTablePaginationObject,
+  DataTableSortState,
+} from '@clyso/clyso-ui-kit';
+import type { ChorusCredential, ChorusStorage } from '@/utils/types/chorus';
 import { ChorusService } from '@/services/ChorusService';
 import { RouteName } from '@/utils/types/router';
+import { GeneralHelper } from '@/utils/helpers/GeneralHelper';
+
+const CREDENTIALS_PAGE_SIZES = [10, 20, 30, 50, 100] as const;
 
 interface ChorusStorageDetailsState {
   isLoading: boolean;
   hasError: boolean;
   storage: ChorusStorage | null;
+
+  credentialsList: ChorusCredential[];
+  credentialsSorter: DataTableSortState | null;
+  credentialsPage: number;
+  credentialsPageSize: number;
+  credentialsFilterAlias: string[];
 }
 
 function getInitialState(): ChorusStorageDetailsState {
@@ -32,6 +45,12 @@ function getInitialState(): ChorusStorageDetailsState {
     isLoading: false,
     hasError: false,
     storage: null,
+
+    credentialsList: [],
+    credentialsSorter: null,
+    credentialsPage: 1,
+    credentialsPageSize: CREDENTIALS_PAGE_SIZES[0],
+    credentialsFilterAlias: [],
   };
 }
 
@@ -53,6 +72,8 @@ export const useChorusStorageDetailsStore = defineStore(
 
         if (state.storage === null) {
           router.push({ name: RouteName.CHORUS_STORAGES });
+        } else {
+          state.credentialsList = state.storage.credentials;
         }
       } catch {
         state.hasError = true;
@@ -61,6 +82,56 @@ export const useChorusStorageDetailsStore = defineStore(
       }
     }
 
+    const filteredCredentials = computed<ChorusCredential[]>(() =>
+      state.credentialsList.filter((credential) => {
+        return (
+          !state.credentialsFilterAlias.length ||
+          state.credentialsFilterAlias.includes(credential.alias)
+        );
+      }),
+    );
+
+    const isCredentialsFiltered = computed<boolean>(
+      () => state.credentialsFilterAlias.length !== 0,
+    );
+
+    const computedCredentials = computed<ChorusCredential[]>(() => {
+      const sorted = state.credentialsSorter
+        ? GeneralHelper.orderBy(
+            filteredCredentials.value,
+            [state.credentialsSorter.columnKey],
+            [state.credentialsSorter.order === 'ascend' ? 'asc' : 'desc'],
+          )
+        : filteredCredentials.value;
+
+      const start = (state.credentialsPage - 1) * state.credentialsPageSize;
+      const end = state.credentialsPage * state.credentialsPageSize;
+
+      return sorted.slice(start, end);
+    });
+
+    const credentialsPagination = computed<DataTablePaginationObject>(() => ({
+      page: state.credentialsPage,
+      pageSize: state.credentialsPageSize,
+      showSizePicker: true,
+      pageSizes: [...CREDENTIALS_PAGE_SIZES],
+      pageCount: Math.ceil(
+        filteredCredentials.value.length / state.credentialsPageSize,
+      ),
+      itemCount: filteredCredentials.value.length,
+      prefix({ itemCount }) {
+        if (state.isLoading || state.hasError) {
+          return '';
+        }
+
+        if (isCredentialsFiltered.value) {
+          return `Filtered: ${filteredCredentials.value.length} / Total: ${state.credentialsList.length}`;
+        }
+
+        return `Total: ${itemCount}`;
+      },
+    }));
+
     async function $reset() {
       Object.assign(state, getInitialState());
     }
@@ -68,6 +139,8 @@ export const useChorusStorageDetailsStore = defineStore(
     return {
       ...toRefs(state),
       initStorageDetails,
+      computedCredentials,
+      credentialsPagination,
       $reset,
     };
   },

--- a/ui/src/utils/types/icon.ts
+++ b/ui/src/utils/types/icon.ts
@@ -26,6 +26,7 @@ export enum IconName {
   BASE_CYLINDER = 'base-cylinder',
   BASE_CHORUS_LOGO = 'base-chorus-logo',
   BASE_CLOSE_CIRCLE = 'base-close-circle',
+  BASE_CREATE = 'base-create',
   BASE_TIMER = 'base-timer',
   BASE_TRASH = 'base-trash',
   BASE_PLAY = 'base-play',


### PR DESCRIPTION
## Pull Request

### Description
<!--
Describe the changes in this pull request and the problem it solves or feature it adds.
-->

On the storage details page, add a list of the existing credentials for the storage.

The PR takes also care of: fix loading representation for replication filters

<img width="1142" height="855" alt="Screenshot 2026-04-28 at 13 58 52" src="https://github.com/user-attachments/assets/05e1cd8f-6508-4a52-951f-7eccc33c6237" />

### Related Issue
Link to the GitHub issue (if applicable): #[issue number]

### Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [ ] My commits include a `Signed-off-by` line to certify agreement with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
- [ ] `make test` passing
- [ ] I have updated documentation in [README.md](README.md) if applicable.

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
