### PR TITLE
fix(credentials): sync cache after creation

### DIFF
--- a/pkg/objstore/credentials.go
+++ b/pkg/objstore/credentials.go
@@ -481,6 +481,10 @@ func (s *credsSvc) storeCred(ctx context.Context, storType dom.StorageType, stor
 	if _, err := tx.Exec(ctx); err != nil {
 		return fmt.Errorf("failed to set S3 credentials in redis: %w", err)
 	}
+	// sync local cache immediately so subsequent reads see the new credential
+	if err := s.sync(ctx); err != nil {
+		return fmt.Errorf("failed to sync credentials cache after update: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Sync the local cache once a new credential has been created. Otherwise the new credential may not be listed in a subsequent read.

## Pull Request

### Description
<!--
Describe the changes in this pull request and the problem it solves or feature it adds.
-->

### Related Issue
Link to the GitHub issue (if applicable): #[issue number]

### Checklist
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [ ] My commits include a `Signed-off-by` line to certify agreement with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
- [ ] `make test` passing
- [ ] I have updated documentation in [README.md](README.md) if applicable.

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
