### PR TITLE
fix: use global vars for Prometheus metrics registration in middleware

### DIFF
--- a/pkg/metrics/http_middleware.go
+++ b/pkg/metrics/http_middleware.go
@@ -40,60 +40,60 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+var proxyTotalRequests = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "proxy_requests_total",
+		Help: "Number of requests to chorus s3 proxy.",
+	},
+	[]string{"method"},
+)
+
+var proxyResponseStatus = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "proxy_response_status",
+		Help: "Status of chorus s3 proxy response.",
+	},
+	[]string{"status"},
+)
+
+var proxyHttpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "proxy_response_time_seconds",
+	Help:    "Duration of chorus s3 proxy requests.",
+	Buckets: prometheus.DefBuckets,
+}, []string{"method"})
+
 func ProxyMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		var totalRequests = promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "proxy_requests_total",
-				Help: "Number of requests to chorus s3 proxy.",
-			},
-			[]string{"method"},
-		)
-
-		var responseStatus = promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "proxy_response_status",
-				Help: "Status of chorus s3 proxy response.",
-			},
-			[]string{"status"},
-		)
-
-		var httpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "proxy_response_time_seconds",
-			Help:    "Duration of chorus s3 proxy requests.",
-			Buckets: prometheus.DefBuckets,
-		}, []string{"method"})
-
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			method := xctx.GetMethod(r.Context())
 
-			timer := prometheus.NewTimer(httpDuration.WithLabelValues(method.String()))
+			timer := prometheus.NewTimer(proxyHttpDuration.WithLabelValues(method.String()))
 			rw := NewResponseWriter(w)
 			next.ServeHTTP(rw, r)
 			statusCode := rw.statusCode
 
-			responseStatus.WithLabelValues(strconv.Itoa(statusCode)).Inc()
-			totalRequests.WithLabelValues(method.String()).Inc()
+			proxyResponseStatus.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+			proxyTotalRequests.WithLabelValues(method.String()).Inc()
 			timer.ObserveDuration()
 		})
 	}
 }
 
-func AgentMiddleware(next http.Handler) http.Handler {
-	var totalRequests = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "agent_requests_total",
-			Help: "Number of requests to chorus agent.",
-		},
-		[]string{"status"},
-	)
+var agentTotalRequests = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "agent_requests_total",
+		Help: "Number of requests to chorus agent.",
+	},
+	[]string{"status"},
+)
 
+func AgentMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		rw := NewResponseWriter(w)
 		next.ServeHTTP(rw, r)
 		statusCode := rw.statusCode
 
-		totalRequests.WithLabelValues(strconv.Itoa(statusCode)).Inc()
+		agentTotalRequests.WithLabelValues(strconv.Itoa(statusCode)).Inc()
 	})
 }


### PR DESCRIPTION
Closes #200 cherry pick from #201 