### PR TITLE
Bug fixed for ceph RGW diff fix

### DIFF
--- a/service/worker/handler/diff_handlers.go
+++ b/service/worker/handler/diff_handlers.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hibiken/asynq"
 	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
 
 	"github.com/clyso/chorus/pkg/dom"
 	"github.com/clyso/chorus/pkg/entity"
@@ -803,6 +804,7 @@ func (r *DiffSvc) EnsureObjectsDeleted(ctx context.Context, id entity.DiffFixID,
 		return fmt.Errorf("unable to get objects to remove: %w", err)
 	}
 
+	zerolog.Ctx(ctx).Info().Int("count", len(objectsToRemove)).Msg("EnsureObjectsDeleted: checking objects to remove")
 	client, err := r.clients.AsCommon(ctx, location.Storage, user)
 	if err != nil {
 		return fmt.Errorf("unable to obtain client: %w", err)

--- a/service/worker/handler/migration_obj_copy_handler.go
+++ b/service/worker/handler/migration_obj_copy_handler.go
@@ -74,9 +74,13 @@ func (s *svc) HandleMigrationObjCopy(ctx context.Context, t *asynq.Task) (err er
 	}
 	fromVer, toVer := versions.From, versions.To
 
-	if fromVer != 0 && fromVer <= toVer {
+	isDiffFix := t.Type() == tasks.TypeDiffFixCopyS3
+	if !isDiffFix && fromVer != 0 && fromVer <= toVer {
 		logger.Info().Int("from_ver", fromVer).Int("to_ver", toVer).Msg("migration obj copy: identical from/to obj version: skip copy")
 		return nil
+	}
+	if isDiffFix {
+		logger.Info().Int("from_ver", fromVer).Int("to_ver", toVer).Msg("diff fix copy: proceeding with copy despite version check")
 	}
 	// 1. sync obj meta and content
 	err = lock.Do(ctx, time.Second*2, func() error {
@@ -105,7 +109,11 @@ func (s *svc) HandleMigrationObjCopy(ctx context.Context, t *asynq.Task) (err er
 			return fmt.Errorf("migration obj copy: unable to update obj meta: %w", err)
 		}
 	}
-	logger.Info().Msg("migration obj copy: done")
+	if isDiffFix {
+		logger.Info().Msg("diff fix copy: object copied successfully")
+	} else {
+		logger.Info().Msg("migration obj copy: done")
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Diff Fix for Ceph RGW

### Description

This PR addresses issues identified during diff migrations against Ceph RGW and fixes cases where valid copy operations were not executed.

#### 1. Object Key Normalization Fix

Updated the `normalizeOutputName` and `normalizeInputName` functions to stop prepending a leading `/` to object keys.

Previously, object keys for non-MinIO providers (such as Ceph RGW) were normalized with a leading slash, causing S3 operations including:

- `StatObject`
- `GetObject`
- `PutObject`

to fail with errors such as:

> object missing in source

Object keys are now preserved as-is, ensuring compatibility with Ceph RGW object lookups.

#### 2. Diff Pipeline Fix

**File:** `service/worker/handler/diff_handlers.go`

Changes:

- Removed the `len(objectsToRemove) == 0` early return from `EnsureObjectsDeleted()`
- Ensured diff-fix copy tasks are always enqueued, even when there are no objects to delete
- Added `fixCopySetStore.Drop()` to clean up stale Redis state before creating new diff-fix copy tasks

This prevents scenarios where the diff-fix workflow exits prematurely and skips required copy operations.

#### 3. Diff Fix Copy Version Check Bypass

**File:** `service/worker/handler/migration_obj_copy_handler.go`

Added an `isDiffFix` check to bypass the version validation below for diff-fix copy tasks:

```go
fromVer != 0 && fromVer <= toVer
```

This prevents valid diff-fix copy operations from being skipped due to version comparison logic that is intended for normal migration workflows rather than repair or reconciliation tasks.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] My commits include a `Signed-off-by` line to certify agreement with the pdated documentation in [README.md](README.md) if applicable.

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) _CONDUCT.md.