### PR TITLE
proxy: support presigned (query string auth) SigV4 requests

### DIFF
--- a/pkg/s3/presign.go
+++ b/pkg/s3/presign.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2026 Clyso GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/clyso/chorus/pkg/dom"
+)
+
+const iso8601Format = "20060102T150405Z"
+
+// PreSignValues holds the parsed authentication values of a presigned
+// (query-string authenticated) AWS Signature Version '4' request.
+type PreSignValues struct {
+	Date time.Time
+	SignValues
+	Expires time.Duration
+}
+
+// ParsePreSignV4 parses the query-string authentication parameters of a
+// presigned AWS Signature Version '4' request into PreSignValues.
+// See https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html.
+func ParsePreSignV4(query url.Values) (psv PreSignValues, err error) {
+	if query.Get(AmzAlgorithm) != signV4Algorithm {
+		return psv, fmt.Errorf("%w: parse presign v4: algorithm %q is not supported", dom.ErrAuth, query.Get(AmzAlgorithm))
+	}
+
+	// Save credential.
+	psv.Credential, err = parseCredentialHeader("Credential=" + query.Get(AmzCredential))
+	if err != nil {
+		return psv, err
+	}
+
+	// Save date.
+	psv.Date, err = time.Parse(iso8601Format, query.Get(AmzDate))
+	if err != nil {
+		return psv, fmt.Errorf("%w: parse presign v4: %q - %q invalid date format", dom.ErrAuth, AmzDate, query.Get(AmzDate))
+	}
+
+	// Save expires.
+	expiresStr := query.Get(AmzExpires)
+	if expiresStr == "" {
+		return psv, fmt.Errorf("%w: parse presign v4: %q param is missing", dom.ErrAuth, AmzExpires)
+	}
+	expires, e := strconv.ParseInt(expiresStr, 10, 64)
+	if e != nil {
+		return psv, fmt.Errorf("%w: parse presign v4: %q - %q is invalid", dom.ErrAuth, AmzExpires, expiresStr)
+	}
+	psv.Expires = time.Duration(expires) * time.Second
+
+	// Save signed headers.
+	signedHeaders := query.Get(AmzSignedHeaders)
+	if signedHeaders == "" {
+		return psv, fmt.Errorf("%w: parse presign v4: %q param is missing", dom.ErrAuth, AmzSignedHeaders)
+	}
+	psv.SignedHeaders = strings.Split(signedHeaders, ";")
+
+	// Save signature.
+	psv.Signature = query.Get(AmzSignature)
+	if psv.Signature == "" {
+		return psv, fmt.Errorf("%w: parse presign v4: %q param is missing", dom.ErrAuth, AmzSignature)
+	}
+
+	return psv, nil
+}

--- a/service/proxy/auth/middleware.go
+++ b/service/proxy/auth/middleware.go
@@ -68,6 +68,12 @@ func (m *middleware) Wrap(next http.Handler) http.Handler {
 			util.WriteError(r.Context(), w, err)
 			return
 		}
+		if !isRequestSignatureV4(r) && isRequestPresignedSignatureV4(r) {
+			// the presigned query-string auth params were validated:
+			// strip them so that the request forwarded to the backend
+			// carries only the Authorization header computed by the proxy.
+			removePresignParams(r)
+		}
 		ctx := log.WithUser(r.Context(), user)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
@@ -103,10 +109,13 @@ func (m *middleware) getCred(accessKey string) (credMeta, error) {
 }
 
 func (m *middleware) isReqAuthenticated(r *http.Request) (string, error) {
-	if isRequestSignatureV4(r) {
+	switch {
+	case isRequestSignatureV4(r):
 		sha256sum := getContentSha256Cksum(r)
 		return m.doesSignatureV4Match(sha256sum, r)
-	} else if m.allowV2 && isRequestSignatureV2(r) {
+	case isRequestPresignedSignatureV4(r):
+		return m.doesPresignedSignatureV4Match(r)
+	case m.allowV2 && isRequestSignatureV2(r):
 		return m.doesSignatureV2Match(r)
 	}
 	return "", mclient.ErrorResponse{

--- a/service/proxy/auth/signature_v4_presign.go
+++ b/service/proxy/auth/signature_v4_presign.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2026 Clyso GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth
+
+import (
+	"encoding/xml"
+	"net/http"
+	"time"
+
+	mclient "github.com/minio/minio-go/v7"
+
+	xctx "github.com/clyso/chorus/pkg/ctx"
+	"github.com/clyso/chorus/pkg/s3"
+)
+
+const (
+	// presignedMinExpires and presignedMaxExpires bound the X-Amz-Expires
+	// parameter of a presigned URL, as in AWS S3 (1 second to 7 days).
+	presignedMinExpires = time.Second
+	presignedMaxExpires = 7 * 24 * time.Hour
+	// presignedMaxClockSkew is the clock skew allowed between the client
+	// and the proxy when checking that a presigned URL is not used before
+	// its signing date.
+	presignedMaxClockSkew = 15 * time.Minute
+)
+
+// isRequestPresignedSignatureV4 verifies if the request has AWS Signature
+// Version '4' authentication parameters in the query string (presigned URL).
+// See https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html.
+func isRequestPresignedSignatureV4(r *http.Request) bool {
+	_, ok := r.URL.Query()[s3.AmzCredential]
+	return ok
+}
+
+// doesPresignedSignatureV4Match verifies the signature of a presigned
+// (query-string authenticated) AWS Signature Version '4' request and
+// returns the authenticated user.
+func (m *middleware) doesPresignedSignatureV4Match(r *http.Request) (string, error) {
+	query := r.URL.Query()
+
+	psv, err := s3.ParsePreSignV4(query)
+	if err != nil {
+		return "", err
+	}
+
+	credInfo, err := m.getCred(psv.Credential.AccessKey)
+	if err != nil {
+		return "", err
+	}
+	cred := credInfo.cred
+
+	if psv.Expires < presignedMinExpires || psv.Expires > presignedMaxExpires {
+		return "", mclient.ErrorResponse{
+			XMLName:    xml.Name{},
+			Code:       "AuthorizationQueryParametersError",
+			Message:    "X-Amz-Expires must be from 1 second to 604800 seconds (7 days).",
+			BucketName: xctx.GetBucket(r.Context()),
+			Key:        xctx.GetObject(r.Context()),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	now := time.Now().UTC()
+	if psv.Date.After(now.Add(presignedMaxClockSkew)) {
+		return "", mclient.ErrorResponse{
+			XMLName:    xml.Name{},
+			Code:       "AccessDenied",
+			Message:    "Request is not valid yet",
+			BucketName: xctx.GetBucket(r.Context()),
+			Key:        xctx.GetObject(r.Context()),
+			StatusCode: http.StatusForbidden,
+		}
+	}
+	if now.Sub(psv.Date) > psv.Expires {
+		return "", mclient.ErrorResponse{
+			XMLName:    xml.Name{},
+			Code:       "AccessDenied",
+			Message:    "Request has expired",
+			BucketName: xctx.GetBucket(r.Context()),
+			Key:        xctx.GetObject(r.Context()),
+			StatusCode: http.StatusForbidden,
+		}
+	}
+
+	extractedSignedHeaders, err := s3.ExtractSignedHeaders(psv.SignedHeaders, r)
+	if err != nil {
+		return "", err
+	}
+
+	// The payload of a presigned request is not signed: the recommended
+	// value UNSIGNED-PAYLOAD is used unless the client explicitly signed
+	// a payload checksum through the X-Amz-Content-Sha256 query parameter.
+	hashedPayload := query.Get(s3.AmzContentSha256)
+	if hashedPayload == "" {
+		hashedPayload = unsignedPayload
+	}
+
+	// The signature covers every query parameter except X-Amz-Signature.
+	query.Del(s3.AmzSignature)
+	queryStr := query.Encode()
+
+	canonicalRequest := getCanonicalV4Request(extractedSignedHeaders, hashedPayload, queryStr, r.URL.Path, r.Method)
+	stringToSign := getV4StringToSign(canonicalRequest, psv.Date, psv.Credential.GetScope())
+	signingKey := getV4SigningKey(cred.SecretAccessKey, psv.Credential.Scope.Date, psv.Credential.Scope.Region)
+	newSignature := getV4Signature(signingKey, stringToSign)
+
+	if !compareSignatureV4(newSignature, psv.Signature) {
+		return "", mclient.ErrorResponse{
+			XMLName:    xml.Name{},
+			Code:       "SignatureDoesNotMatch",
+			Message:    "The request signature that the server calculated does not match the signature that you provided. Check your AWS secret access key and signing method. For more information, see REST Authentication and SOAP Authentication.",
+			BucketName: xctx.GetBucket(r.Context()),
+			Key:        xctx.GetObject(r.Context()),
+			StatusCode: http.StatusForbidden,
+		}
+	}
+
+	return credInfo.user, nil
+}
+
+// removePresignParams strips the AWS Signature Version '4' query-string
+// authentication parameters from the request URL. It is called after a
+// presigned request has been authenticated, so that the request forwarded
+// to the storage backend carries a single authentication mechanism: the
+// Authorization header computed by the proxy.
+func removePresignParams(r *http.Request) {
+	query := r.URL.Query()
+	for _, param := range []string{
+		s3.AmzAlgorithm,
+		s3.AmzCredential,
+		s3.AmzDate,
+		s3.AmzExpires,
+		s3.AmzSignedHeaders,
+		s3.AmzSignature,
+		s3.AmzSecurityToken,
+		s3.AmzContentSha256,
+	} {
+		query.Del(param)
+	}
+	r.URL.RawQuery = query.Encode()
+}

--- a/service/proxy/auth/signature_v4_presign_test.go
+++ b/service/proxy/auth/signature_v4_presign_test.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2026 Clyso GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mclient "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/signer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/clyso/chorus/pkg/s3"
+)
+
+const (
+	presignTestAccessKey = "test-access-key"
+	presignTestSecretKey = "test-secret-key"
+	presignTestUser      = "test-user"
+)
+
+func presignTestMiddleware() *middleware {
+	return &middleware{
+		custom: map[string]credMeta{
+			presignTestAccessKey: {
+				cred: s3.CredentialsV4{
+					AccessKeyID:     presignTestAccessKey,
+					SecretAccessKey: presignTestSecretKey,
+				},
+				user: presignTestUser,
+			},
+		},
+		endpoint: "http://s3.example.com:9669",
+	}
+}
+
+func presignTestRequest(t *testing.T, location string, expires int64) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/bucket-test/object.png", nil)
+	req.Host = "s3.example.com:9669"
+	return signer.PreSignV4(*req, presignTestAccessKey, presignTestSecretKey, "", location, expires)
+}
+
+func TestDoesPresignedSignatureV4Match(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid presigned request", func(t *testing.T) {
+		t.Parallel()
+		req := presignTestRequest(t, "us-east-1", 3600)
+		m := presignTestMiddleware()
+
+		got, err := m.doesPresignedSignatureV4Match(req)
+		require.NoError(t, err)
+		require.Equal(t, presignTestUser, got)
+	})
+
+	t.Run("non-default region in credential scope", func(t *testing.T) {
+		t.Parallel()
+		// Ceph RGW clients commonly presign with the zonegroup name
+		// (e.g. "default") instead of an AWS region.
+		req := presignTestRequest(t, "default", 3600)
+		m := presignTestMiddleware()
+
+		got, err := m.doesPresignedSignatureV4Match(req)
+		require.NoError(t, err)
+		require.Equal(t, presignTestUser, got)
+	})
+
+	t.Run("preserves non-auth query params", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/bucket-test/object.png?response-content-disposition=attachment", nil)
+		req.Host = "s3.example.com:9669"
+		req = signer.PreSignV4(*req, presignTestAccessKey, presignTestSecretKey, "", "us-east-1", 3600)
+		m := presignTestMiddleware()
+
+		got, err := m.doesPresignedSignatureV4Match(req)
+		require.NoError(t, err)
+		require.Equal(t, presignTestUser, got)
+	})
+
+	t.Run("wrong secret key", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/bucket-test/object.png", nil)
+		req.Host = "s3.example.com:9669"
+		req = signer.PreSignV4(*req, presignTestAccessKey, "wrong-secret-key", "", "us-east-1", 3600)
+		m := presignTestMiddleware()
+
+		_, err := m.doesPresignedSignatureV4Match(req)
+		var s3Err mclient.ErrorResponse
+		require.ErrorAs(t, err, &s3Err)
+		require.Equal(t, "SignatureDoesNotMatch", s3Err.Code)
+	})
+
+	t.Run("unknown access key", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/bucket-test/object.png", nil)
+		req.Host = "s3.example.com:9669"
+		req = signer.PreSignV4(*req, "unknown-access-key", presignTestSecretKey, "", "us-east-1", 3600)
+		m := presignTestMiddleware()
+
+		_, err := m.doesPresignedSignatureV4Match(req)
+		var s3Err mclient.ErrorResponse
+		require.ErrorAs(t, err, &s3Err)
+		require.Equal(t, "InvalidAccessKeyId", s3Err.Code)
+	})
+
+	t.Run("expired request", func(t *testing.T) {
+		t.Parallel()
+		req := presignTestRequest(t, "us-east-1", 3600)
+		// rewrite the signing date to the past: the expiry check fires
+		// before the signature check.
+		query := req.URL.Query()
+		query.Set(s3.AmzDate, time.Now().UTC().Add(-2*time.Hour).Format("20060102T150405Z"))
+		req.URL.RawQuery = query.Encode()
+		m := presignTestMiddleware()
+
+		_, err := m.doesPresignedSignatureV4Match(req)
+		var s3Err mclient.ErrorResponse
+		require.ErrorAs(t, err, &s3Err)
+		require.Equal(t, "AccessDenied", s3Err.Code)
+		require.Equal(t, "Request has expired", s3Err.Message)
+	})
+
+	t.Run("request not valid yet", func(t *testing.T) {
+		t.Parallel()
+		req := presignTestRequest(t, "us-east-1", 3600)
+		query := req.URL.Query()
+		query.Set(s3.AmzDate, time.Now().UTC().Add(2*time.Hour).Format("20060102T150405Z"))
+		req.URL.RawQuery = query.Encode()
+		m := presignTestMiddleware()
+
+		_, err := m.doesPresignedSignatureV4Match(req)
+		var s3Err mclient.ErrorResponse
+		require.ErrorAs(t, err, &s3Err)
+		require.Equal(t, "AccessDenied", s3Err.Code)
+		require.Equal(t, "Request is not valid yet", s3Err.Message)
+	})
+
+	t.Run("expires out of bounds", func(t *testing.T) {
+		t.Parallel()
+		req := presignTestRequest(t, "us-east-1", 700000) // > 7 days
+		m := presignTestMiddleware()
+
+		_, err := m.doesPresignedSignatureV4Match(req)
+		var s3Err mclient.ErrorResponse
+		require.ErrorAs(t, err, &s3Err)
+		require.Equal(t, "AuthorizationQueryParametersError", s3Err.Code)
+	})
+}
+
+func TestIsReqAuthenticatedPresigned(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dispatches presigned request", func(t *testing.T) {
+		t.Parallel()
+		req := presignTestRequest(t, "us-east-1", 3600)
+		m := presignTestMiddleware()
+
+		got, err := m.isReqAuthenticated(req)
+		require.NoError(t, err)
+		require.Equal(t, presignTestUser, got)
+	})
+
+	t.Run("request without any credentials is still rejected", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/bucket-test/object.png", nil)
+		req.Host = "s3.example.com:9669"
+		m := presignTestMiddleware()
+
+		_, err := m.isReqAuthenticated(req)
+		var s3Err mclient.ErrorResponse
+		require.ErrorAs(t, err, &s3Err)
+		require.Equal(t, "CredentialsNotSupported", s3Err.Code)
+	})
+}
+
+func TestWrapStripsPresignParams(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/bucket-test/object.png?response-content-disposition=attachment", nil)
+	req.Host = "s3.example.com:9669"
+	req = signer.PreSignV4(*req, presignTestAccessKey, presignTestSecretKey, "", "us-east-1", 3600)
+	m := presignTestMiddleware()
+
+	var forwarded *http.Request
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		forwarded = r
+	})
+	rec := httptest.NewRecorder()
+	m.Wrap(next).ServeHTTP(rec, req)
+
+	require.NotNil(t, forwarded, "request should have been forwarded to the next handler")
+	query := forwarded.URL.Query()
+	for _, param := range []string{
+		s3.AmzAlgorithm, s3.AmzCredential, s3.AmzDate, s3.AmzExpires,
+		s3.AmzSignedHeaders, s3.AmzSignature,
+	} {
+		require.NotContains(t, query, param)
+	}
+	// non-auth query params must be preserved for the backend.
+	require.Equal(t, "attachment", query.Get("response-content-disposition"))
+}


### PR DESCRIPTION
### Description

The proxy auth middleware only recognizes header-based `Authorization` signatures (SigV4, and SigV2 when enabled). A presigned URL carries its SigV4 parameters in the query string (`X-Amz-Algorithm`, `X-Amz-Credential`, `X-Amz-Date`, `X-Amz-Expires`, `X-Amz-SignedHeaders`, `X-Amz-Signature`) and no `Authorization` header, so `isReqAuthenticated()` falls through to `400 CredentialsNotSupported` without contacting the backend. Any client relying on presigned URLs (browser-based download flows of S3 gateways and web front-ends, `aws s3 presign`, `rclone link`, SDK `generate_presigned_url`) is broken behind the proxy.

Changes:

- **`pkg/s3/presign.go`**: `ParsePreSignV4(url.Values)` parses the query-string authentication parameters into `PreSignValues` (credential scope, date, expires, signed headers, signature), mirroring the existing `ParseSignV4` for the `Authorization` header.
- **`service/proxy/auth/signature_v4_presign.go`**:
  - `isRequestPresignedSignatureV4()` detects query-string auth (presence of `X-Amz-Credential`, as in MinIO).
  - `doesPresignedSignatureV4Match()` validates `X-Amz-Expires` bounds (1s..7d), rejects not-yet-valid (15 min skew allowance) and expired requests with the AWS error codes (`AuthorizationQueryParametersError`, `AccessDenied`), then verifies the signature over the canonical request — all query parameters except `X-Amz-Signature`, `UNSIGNED-PAYLOAD` unless a payload checksum was signed — reusing the existing SigV4 helpers, so region handling is identical to the header path (the scope region is used as-is, e.g. RGW zonegroup names like `default`).
  - `removePresignParams()` strips the `X-Amz-*` auth parameters after successful validation, so the request forwarded to the backend carries a single authentication mechanism: the `Authorization` header computed by the proxy in `pkg/s3client`. Non-auth query parameters (`response-content-disposition`, `versionId`, ...) are preserved.
- **`service/proxy/auth/middleware.go`**: dispatch presigned requests in `isReqAuthenticated()`, strip the auth params in `Wrap()` after successful authentication.

Presigned **SigV2** URLs remain unsupported (out of scope; the SigV2 path still requires the `Authorization` header).

Testing:

- Unit tests in `service/proxy/auth/signature_v4_presign_test.go`: valid presigned GET (including non-AWS region scope `default` and extra `response-*` query params), wrong secret, unknown access key, expired / not-yet-valid dates, out-of-bounds `X-Amz-Expires`, dispatch from `isReqAuthenticated`, `CredentialsNotSupported` preserved for unauthenticated requests, and auth-param stripping through `Wrap()`.
- The verification logic was additionally cross-checked against presigned URLs generated by botocore (path-style, custom port, region `default`, unicode/space object keys, `response-*` params, HEAD, `versionId`, tampered URL and wrong-secret rejection).

### Related Issue

Fixes #255

### Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] My commits include a `Signed-off-by` line to certify agreement with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
- [ ] `make test` passing
- [x] I have updated documentation in [README.md](README.md) if applicable (no documentation change needed).

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)