### PR TITLE
update golang.org/x/crypto to v0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/testcontainers/testcontainers-go v0.44.0
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -925,8 +925,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 h1:qLvzZeaANDgyVOA8pyHCOStGlXn0rseXma+GQjeuv2g=
 golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=


### PR DESCRIPTION
### Description

Bump `golang.org/x/crypto` from v0.55.0 to v0.56.0.

govulncheck (the `vuln` step of `make test`) currently fails on every CI run of the repository with two new advisories against v0.55.0, reached through `test/env/components.go` → testcontainers → `x/crypto/ssh`:

- [GO-2026-6354](https://pkg.go.dev/vuln/GO-2026-6354) — Prevent DoS on deadlocked undecided channel in golang.org/x/crypto/ssh
- [GO-2026-6355](https://pkg.go.dev/vuln/GO-2026-6355) — Prevent DoS on deadlocked established channel in golang.org/x/crypto/ssh

Both are fixed in v0.56.0. Its requirements (`x/net` v0.57.0, `x/sys` v0.47.0, `x/term` v0.45.0, `x/text` v0.41.0) are already satisfied by the current `go.mod`, so no transitive bump is needed; the change is limited to the `x/crypto` require line and its two `go.sum` entries. `tools/bench` and `tools/chorctl` are separate modules not scanned by `make vuln` and are left untouched.

Example failing run: https://github.com/clyso/chorus/actions/runs/34102497603/job/101679893701

### Related Issue

Unblocks CI for #256 (and any other open PR).

### Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] My commits include a `Signed-off-by` line to certify agreement with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
- [ ] `make test` passing (this PR is what makes the `vuln` step pass again; CI will confirm)
- [x] I have updated documentation in [README.md](README.md) if applicable (no documentation change needed).

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)