### PR TITLE
tools/bench: update golang.org/x/crypto to v0.56.0

### DIFF
--- a/tools/bench/go.mod
+++ b/tools/bench/go.mod
@@ -74,7 +74,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/image v0.45.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect

--- a/tools/bench/go.sum
+++ b/tools/bench/go.sum
@@ -229,8 +229,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
 golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=


### PR DESCRIPTION
### Description

Follow-up to #257, which bumped `golang.org/x/crypto` to v0.56.0 in the main module only.

`tools/bench` is a separate module that `replace`s `github.com/clyso/chorus` with `../..`, so it inherits the parent's requirements. Since #257 landed, the `cd tools/bench; go mod tidy` step run by `make test` rewrites `tools/bench/go.mod` and `tools/bench/go.sum` to v0.56.0, and the workflow's final "Check for Uncommitted Changes" step fails on every CI run:

```
Error: Proto generation step has uncommitted changes: M tools/bench/go.mod
M tools/bench/go.sum
```

Example: https://github.com/clyso/chorus/actions/runs/34144738412/job/101814186329 (the `make test` step itself is green there).

This commits the result tidy produces: the `x/crypto` require line in `tools/bench/go.mod` and its two `go.sum` entries. x/crypto v0.55.0 and v0.56.0 declare identical requirements (only the `go` directive changed), so nothing else moves. `tools/chorctl` does not depend on x/crypto and is unaffected.

### Related Issue

Follow-up to #257; unblocks CI for #256.

### Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] My commits include a `Signed-off-by` line to certify agreement with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
- [ ] `make test` passing (the E2E workflow is path-filtered and does not run on go.mod/go.sum-only changes; #256 rebased on this will exercise it)
- [x] I have updated documentation in [README.md](README.md) if applicable (no documentation change needed).

**Note**: By submitting this PR, you agree to license your contributions under the [Apache 2.0 License](LICENSE) and follow our [Code of Conduct](CODE_OF_CONDUCT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)